### PR TITLE
Remove stale API decl

### DIFF
--- a/ast_canopy/cpp/include/ast_canopy.hpp
+++ b/ast_canopy/cpp/include/ast_canopy.hpp
@@ -199,10 +199,6 @@ struct Declarations {
 };
 
 Declarations
-parse_declarations_from_ast(std::string_view ast_file_path,
-                            std::vector<std::string> files_to_retain);
-
-Declarations
 parse_declarations_from_command_line(std::vector<std::string> options,
                                      std::vector<std::string> files_to_retain);
 


### PR DESCRIPTION
This PR removes the stale `parse_declaration_from_ast` header, implementations are removed in an earlier PR, but I forgot to remove the declaration in that PR.﻿
