### PR TITLE
CI tests depends on style checks

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -27,6 +27,7 @@ jobs:
       enable_check_generated_files: false
   legacy_tests:
     name: Runs on legacy hardware and older CTK versions (V100, 12.3)
+    needs: checks
     secrets: inherit
     uses: ./.github/workflows/setup_build_test.yaml
     with:
@@ -37,6 +38,7 @@ jobs:
       CPU: "amd64"
   frontier_tests:
     name: Runs on newer hardware and latest CTK versions (A100, 12.4)
+    needs: checks
     secrets: inherit
     uses: ./.github/workflows/setup_build_test.yaml
     with:


### PR DESCRIPTION
Currently "legacy_test" and "frontier_test" runs in parallel of style checks job in CI.
In theory test jobs should not run at all if the PR doesn't pass style checks.﻿
