### PR TITLE
Fix Bug: Numbast do not create proper llvm structure type when lowering struct with private / protected fields

### DIFF
--- a/ast_canopy/ast_canopy/api.py
+++ b/ast_canopy/ast_canopy/api.py
@@ -150,6 +150,10 @@ def parse_declarations_from_source(
         A tuple containing lists of declaration objects from the source file.
         See decl.py and pylibastcanopy.pyi for the declaration object types.
     """
+
+    if not os.path.exists(source_file_path):
+        raise FileNotFoundError(f"File not found: {source_file_path}")
+
     if cccl_root:
         cccl_libs = [
             os.path.join(cccl_root, "libcudacxx", "include"),

--- a/ast_canopy/ast_canopy/pylibastcanopy.pyi
+++ b/ast_canopy/ast_canopy/pylibastcanopy.pyi
@@ -1,5 +1,5 @@
 from _typeshed import Incomplete
-from typing import ClassVar, List, overload
+from typing import ClassVar, overload
 
 class ClassTemplate(Template):
     num_min_required_args: int
@@ -7,21 +7,22 @@ class ClassTemplate(Template):
     def __init__(self, *args, **kwargs) -> None: ...
 
 class Declarations:
-    class_templates: List[ClassTemplate]
-    enums: List[Enum]
-    function_templates: List[FunctionTemplate]
-    functions: List[Function]
-    records: List[Record]
-    typedefs: List[Typedef]
+    class_templates: list[ClassTemplate]
+    enums: list[Enum]
+    function_templates: list[FunctionTemplate]
+    functions: list[Function]
+    records: list[Record]
+    typedefs: list[Typedef]
     def __init__(self, *args, **kwargs) -> None: ...
 
 class Enum:
-    enumerator_values: List[str]
-    enumerators: List[str]
+    enumerator_values: list[str]
+    enumerators: list[str]
     name: str
     def __init__(self, arg0) -> None: ...
 
 class Field:
+    access: access_kind
     name: str
     type_: Type
     def __init__(self, *args, **kwargs) -> None: ...
@@ -29,7 +30,7 @@ class Field:
 class Function:
     exec_space: execution_space
     name: str
-    params: List[ParamVar]
+    params: list[ParamVar]
     return_type: Type
     def __init__(self, *args, **kwargs) -> None: ...
 
@@ -50,17 +51,17 @@ class ParamVar:
 
 class Record:
     alignof_: int
-    fields: List[Field]
-    methods: List[Method]
+    fields: list[Field]
+    methods: list[Method]
     name: str
-    nested_class_templates: List[ClassTemplate]
-    nested_records: List[Record]
+    nested_class_templates: list[ClassTemplate]
+    nested_records: list[Record]
     sizeof_: int
-    templated_methods: List[FunctionTemplate]
+    templated_methods: list[FunctionTemplate]
     def __init__(self, *args, **kwargs) -> None: ...
 
 class Template:
-    template_parameters: List[TemplateParam]
+    template_parameters: list[TemplateParam]
     def __init__(self, *args, **kwargs) -> None: ...
 
 class TemplateParam:
@@ -83,6 +84,23 @@ class Typedef:
     name: str
     underlying_name: str
     def __init__(self, *args, **kwargs) -> None: ...
+
+class access_kind:
+    __members__: ClassVar[dict] = ...  # read-only
+    __entries: ClassVar[dict] = ...
+    private_: ClassVar[access_kind] = ...
+    protected_: ClassVar[access_kind] = ...
+    public_: ClassVar[access_kind] = ...
+    def __init__(self, value: int) -> None: ...
+    def __eq__(self, other: object) -> bool: ...
+    def __hash__(self) -> int: ...
+    def __index__(self) -> int: ...
+    def __int__(self) -> int: ...
+    def __ne__(self, other: object) -> bool: ...
+    @property
+    def name(self) -> str: ...
+    @property
+    def value(self) -> int: ...
 
 class execution_space:
     __members__: ClassVar[dict] = ...  # read-only
@@ -141,7 +159,6 @@ class template_param_kind:
     @property
     def value(self) -> int: ...
 
-def parse_declarations_from_ast(arg0: str, arg1: List[str]) -> Declarations: ...
 def parse_declarations_from_command_line(
-    arg0: List[str], arg1: List[str]
+    arg0: list[str], arg1: list[str]
 ) -> Declarations: ...

--- a/ast_canopy/cpp/include/ast_canopy.hpp
+++ b/ast_canopy/cpp/include/ast_canopy.hpp
@@ -33,6 +33,8 @@ enum class method_kind {
 
 enum class template_param_kind { type, non_type, template_ };
 
+enum class access_kind { public_, protected_, private_ };
+
 struct Enum {
   Enum(const std::string &name, const std::vector<std::string> &enumerators,
        const std::vector<std::string> &enumerator_values)
@@ -63,11 +65,13 @@ private:
 };
 
 struct Field {
-  Field(const clang::FieldDecl *FD);
-  Field(const std::string &name, const Type &type) : name(name), type(type){};
+  Field(const clang::FieldDecl *FD, const clang::AccessSpecifier &AS);
+  Field(const std::string &name, const Type &type, const access_kind &access)
+      : name(name), type(type), access(access){};
 
   std::string name;
   Type type;
+  access_kind access;
 };
 
 struct ParamVar {

--- a/ast_canopy/cpp/src/field.cpp
+++ b/ast_canopy/cpp/src/field.cpp
@@ -5,8 +5,27 @@
 
 #include "ast_canopy.hpp"
 
+#ifndef NDEBUG
+#include <iostream>
+#endif
+
 namespace ast_canopy {
 
-Field::Field(const clang::FieldDecl *FD)
-    : name(FD->getNameAsString()), type(FD->getType(), FD->getASTContext()) {}
+Field::Field(const clang::FieldDecl *FD, const clang::AccessSpecifier &AS)
+    : name(FD->getNameAsString()), type(FD->getType(), FD->getASTContext()) {
+  if (AS == clang::AccessSpecifier::AS_public)
+    access = access_kind::public_;
+  else if (AS == clang::AccessSpecifier::AS_protected)
+    access = access_kind::protected_;
+  else if (AS == clang::AccessSpecifier::AS_private)
+    access = access_kind::private_;
+  else {
+    // Fields in a class / struct must have an access specifier. See logic
+    // in record.cpp.
+#ifndef NDEBUG
+    std::cout << "Access specifier is NONE for: " << name << std::endl;
+#endif
+    access = access_kind::public_;
+  }
+}
 } // namespace ast_canopy

--- a/ast_canopy/tests/data/sample_access_specifier.cu
+++ b/ast_canopy/tests/data/sample_access_specifier.cu
@@ -17,3 +17,14 @@ private:
 protected:
   void Bar4(); // Protected
 };
+
+struct Baz {
+private:
+  int x;
+
+public:
+  int y;
+
+protected:
+  int z;
+};

--- a/ast_canopy/tests/test_parse_from_source.py
+++ b/ast_canopy/tests/test_parse_from_source.py
@@ -6,7 +6,7 @@ import pickle
 
 import pytest
 
-from pylibastcanopy import template_param_kind, execution_space
+from pylibastcanopy import template_param_kind, execution_space, access_kind
 from ast_canopy import parse_declarations_from_source
 
 
@@ -383,7 +383,7 @@ def test_load_ast_access_specifiers(sample_access_specifier_source, test_pickle)
         pickled = [pickle.dumps(s) for s in structs]
         structs = [pickle.loads(p) for p in pickled]
 
-    assert len(structs) == 2
+    assert len(structs) == 3
 
     assert len(structs[0].methods) == 1  # Only 1 public method
     assert structs[0].methods[0].name == "Bar2"
@@ -391,6 +391,20 @@ def test_load_ast_access_specifiers(sample_access_specifier_source, test_pickle)
     assert len(structs[1].methods) == 2  # 2 public methods
     assert structs[1].methods[0].name == "Bar1"
     assert structs[1].methods[1].name == "Bar2"
+
+    # All fields are visible, with access specifier information.
+    assert len(structs[2].fields) == 3
+    assert structs[2].fields[0].name == "x"
+    assert structs[2].fields[0].type_.name == "int"
+    assert structs[2].fields[0].access == access_kind.private_
+
+    assert structs[2].fields[1].name == "y"
+    assert structs[2].fields[1].type_.name == "int"
+    assert structs[2].fields[1].access == access_kind.public_
+
+    assert structs[2].fields[2].name == "z"
+    assert structs[2].fields[2].type_.name == "int"
+    assert structs[2].fields[2].access == access_kind.protected_
 
 
 def test_load_enum(sample_enum_source, test_pickle):

--- a/numbast/tests/data/sample_struct.cuh
+++ b/numbast/tests/data/sample_struct.cuh
@@ -1,0 +1,15 @@
+// clang-format off
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// clang-format on
+
+struct Foo {
+public:
+  int x;
+
+private:
+  int y;
+
+protected:
+  int z;
+};

--- a/numbast/tests/test_struct.py
+++ b/numbast/tests/test_struct.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+from numba import types
+from numba.core.datamodel import StructModel
+
+from llvmlite import ir
+
+from ast_canopy import parse_declarations_from_source
+from numbast import bind_cxx_struct, MemoryShimWriter
+
+from numba.cuda.descriptor import cuda_target
+
+DATA_FOLDER = os.path.join(os.path.dirname(__file__), "data")
+
+
+def test_struct_binding_has_correct_LLVM_type():
+    # This test checks if the bindings of type Foo correctly lowered into
+    # LLVM type { i32, i32, i32 }.
+    p = os.path.join(DATA_FOLDER, "sample_struct.cuh")
+    structs, *_ = parse_declarations_from_source(p, [p], "sm_80")
+    shim_writer = MemoryShimWriter(f"#include {p}")
+    s = bind_cxx_struct(shim_writer, structs[0], types.Type, StructModel)
+
+    nbty = s._nbtype
+    # Get the LLVM type of this front-end type
+    target_ctx = cuda_target.target_context
+    llvm_ty = target_ctx.get_value_type(nbty)
+
+    assert len(llvm_ty.elements) == 3
+    assert all(ty == ir.IntType(32) for ty in llvm_ty.elements)
+    assert not llvm_ty._packed


### PR DESCRIPTION
This PR fixes a bug in Numbast. AST_canopy currently do not parse private fields of structs,
originally this was meant for not creating bindings for non-public attribute / methods of
C++ structs. However, Numbast still needs these information to create the proper LLVM types
during lowering, so that when moving the object around, proper IR with type is emit. This PR
adds back those information, but attaching access specifier information to each field. Numbast
create bindings based on access specifier information, and uses all field information to lower
it to proper LLVM type.

﻿- Parse all fields, and add access specifier information
- update pylibastcanopy stub
- patch numbast to properly generate llvm types for struct models
