### PR TITLE
Insert Copyright in all Sample Data

### DIFF
--- a/ast_canopy/tests/data/sample_access_specifier.cu
+++ b/ast_canopy/tests/data/sample_access_specifier.cu
@@ -1,3 +1,7 @@
+// clang-format off
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// clang-format on
 class Foo {
   void Bar1(); // Private
 public:

--- a/ast_canopy/tests/data/sample_class_template.cu
+++ b/ast_canopy/tests/data/sample_class_template.cu
@@ -1,3 +1,7 @@
+// clang-format off
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// clang-format on
 enum class E { A, B, C };
 
 template <typename T, E e> struct Foo {

--- a/ast_canopy/tests/data/sample_diff_by_cc.cu
+++ b/ast_canopy/tests/data/sample_diff_by_cc.cu
@@ -1,3 +1,7 @@
+// clang-format off
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// clang-format on
 float __device__ constexpr fpi() { return 3.14f; }
 
 struct Functor {

--- a/ast_canopy/tests/data/sample_enum.cu
+++ b/ast_canopy/tests/data/sample_enum.cu
@@ -1,3 +1,7 @@
+// clang-format off
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// clang-format on
 enum Foo { A = 1, B = 2, C = 3 };
 
 enum NoDefaultFoo { D, E, F };

--- a/ast_canopy/tests/data/sample_execution_space.cu
+++ b/ast_canopy/tests/data/sample_execution_space.cu
@@ -1,3 +1,7 @@
+// clang-format off
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// clang-format on
 void __device__ dfoo() {}
 void __host__ hfoo() {}
 void __global__ gfoo() {}

--- a/ast_canopy/tests/data/sample_function.cu
+++ b/ast_canopy/tests/data/sample_function.cu
@@ -1,3 +1,7 @@
+// clang-format off
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// clang-format on
 int __device__ add(int a, int b) { return a + b; }
 
 int __device__ mul(const int &a, int const *b) { return a * (*b); }

--- a/ast_canopy/tests/data/sample_function_template.cu
+++ b/ast_canopy/tests/data/sample_function_template.cu
@@ -1,3 +1,7 @@
+// clang-format off
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// clang-format on
 enum class E { A, B, C };
 
 // Type Template, Non-type template

--- a/ast_canopy/tests/data/sample_nested_struct.cu
+++ b/ast_canopy/tests/data/sample_nested_struct.cu
@@ -1,3 +1,7 @@
+// clang-format off
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// clang-format on
 class Foo {
 public:
   class Bar {

--- a/ast_canopy/tests/data/sample_struct.cu
+++ b/ast_canopy/tests/data/sample_struct.cu
@@ -1,3 +1,7 @@
+// clang-format off
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// clang-format on
 struct alignas(16) foo {
   float2 a;
 

--- a/ast_canopy/tests/data/sample_typedef.cu
+++ b/ast_canopy/tests/data/sample_typedef.cu
@@ -1,3 +1,7 @@
+// clang-format off
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// clang-format on
 typedef struct A {
 } A1;
 


### PR DESCRIPTION
This PR adds the missing copyright headers for all sample data used in tests﻿
