### PR TITLE
Pin `cuda-toolkit` version for dependencies

### DIFF
--- a/ci/setup_build_test.sh
+++ b/ci/setup_build_test.sh
@@ -27,6 +27,11 @@ set +u
 conda activate test
 set -u
 
+which nvcc
+nvcc --version
+
+rapids-logger "Install Numbast and all submodules"
+
 # Install AST_Canopy, Numbast and extensions
 pip install ast_canopy/
 pip install numbast/

--- a/conda/environment.yaml
+++ b/conda/environment.yaml
@@ -20,7 +20,7 @@ dependencies:
   - pre-commit
   - cxx-compiler
   - cuda-version=12.4
-  - cuda-toolkit
+  - cuda-toolkit=12.4
   - cuda-python=12.4
   - pynvjitlink>=0.2.0
   - scikit-build-core

--- a/conda/environment_template.yaml
+++ b/conda/environment_template.yaml
@@ -20,7 +20,7 @@ dependencies:
   - pre-commit
   - cxx-compiler
   - cuda-version={{ cuda_version }}
-  - cuda-toolkit
+  - cuda-toolkit={{ cuda_version }}
   - cuda-python={{ cuda_version }}
   - pynvjitlink>=0.2.0
   - scikit-build-core


### PR DESCRIPTION
As pointed out by Vyas, `cuda-toolkit` is a meta package that does not depend on `cuda-version`. Components of `cuda-toolkit` may depend on `cuda-version`, which previously I relied on that dependency to get the correct CTK components. Some unexpected CI [**success**](https://github.com/NVIDIA/numbast/actions/runs/8897777445/job/24433476729#step:5:443) has shown that the default compiler in CI environment mismatches that defined for `cuda-version`, indicating a transitive dependency failure. Therefore, this PR explicitly pins `cuda-toolkit` package version.
