### PR TITLE
bug fix: conda build workflow uses the wrong test script

### DIFF
--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -84,7 +84,7 @@ jobs:
           env:
             GH_TOKEN: ${{ github.token }}
         - name: Test Conda Package
-          run: "./ci/run_tests.sh"
+          run: "./ci/test_conda.sh"
           env:
             GH_TOKEN: ${{ github.token }}
         - name: Upload Conda Package


### PR DESCRIPTION
This PR fixes a bug introduced in #58. Where the conda package test script is `test_conda.sh`, not `run_test.sh﻿`
