### PR TITLE
Add readme to numbast module

### DIFF
--- a/numbast/README.md
+++ b/numbast/README.md
@@ -8,8 +8,7 @@ Numbast is an auto binding generator for CUDA C++ headers. It consumes parsed he
 
 Currently, the following C++ features are recognized and generated. We use a `__myfloat16` struct declaration in C++ below to demonstrate Numbast features.
 
-```C++
-// demo.cuh
+```Cuda
 struct __attribute__((aligned(2))) __myfloat16
 {
 public:

--- a/numbast/README.md
+++ b/numbast/README.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-Numbast is an auto binding generator for CUDA C++ headers. It consumes parsed headers from `AST_Canopy` and dynamically create new types, data models and lowering for C++ types. 
+Numbast is an auto binding generator for CUDA C++ headers. It consumes parsed headers from `AST_Canopy` and dynamically create new types, data models and lowering for C++ types.
 
 ## Supported CUDA C++ declarations
 

--- a/numbast/README.md
+++ b/numbast/README.md
@@ -1,10 +1,14 @@
 # Numbast Project
 
+# Numbast - auto Numba binding generator
+
 ## Overview
 
-Numbast is the auto binding generator for CUDA C++ headers. It consumes parsed headers from `AST_Canopy` and dynamically create new types, data models and lowering for C++ types. One could see Numbast as a C++-Python syntax translator.
+Numbast is an auto binding generator for CUDA C++ headers. It consumes parsed headers from `AST_Canopy` and dynamically create new types, data models and lowering for C++ types. 
 
 ## Supported CUDA C++ declarations
+
+Currently, the following C++ features are recognized and generated.
 
 - Concrete Struct / Classes (e.g. `struct Foo`)
     - Constructors e.g. `Foo()`
@@ -14,7 +18,7 @@ Numbast is the auto binding generator for CUDA C++ headers. It consumes parsed h
 
 ### Requirement
 
-- `ast_canopy`
+- `ast_canopy>=0.1.0`
 - `numba`>=0.59
 - `pynvjitlink`>=0.22
 
@@ -24,5 +28,5 @@ Numbast organizes its files in [src layout](https://packaging.python.org/en/late
 
 - benchmarks: contain the benchmark for Numbast. Including compilation pipeline overhead measurements.
 - src: contains Numbast module. Each file is organized according to the C++ feature that it's addressing. For example
-`struct.py` handles the declaration of C++ structs.
+`struct.py` handles the C++ structs declarations.
 - tests: contains the tests to each module in Numbast

--- a/numbast/README.md
+++ b/numbast/README.md
@@ -2,16 +2,27 @@
 
 ## Overview
 
-Numbast is the auto binding generator for CUDA C++ headers. It consumes parsed headers from `AST_Canopy` and dynamically create new types, data models and lowering for C++ types. A very high level view of Numbast's future role is that it aims to become a C++-Python syntax translator.
+Numbast is the auto binding generator for CUDA C++ headers. It consumes parsed headers from `AST_Canopy` and dynamically create new types, data models and lowering for C++ types. One could see Numbast as a C++-Python syntax translator.
+
+## Supported CUDA C++ declarations
+
+- Concrete Struct / Classes (e.g. `struct Foo`)
+    - Constructors e.g. `Foo()`
+    - Conversion Operators e.g. `operator float()`
+    - Attribute Read Access e.g. `Foo().x`
+- Concrete Functions `e.g. bar() {}`
 
 ### Requirement
 
-TBA
+- `ast_canopy`
+- `numba`>=0.59
+- `pynvjitlink`>=0.22
 
 ## Folder Structure
 
-TBA
+Numbast organizes its files in [src layout](https://packaging.python.org/en/latest/discussions/src-layout-vs-flat-layout/).
 
-## Tests
-
-TBA
+- benchmarks: contain the benchmark for Numbast. Including compilation pipeline overhead measurements.
+- src: contains Numbast module. Each file is organized according to the C++ feature that it's addressing. For example
+`struct.py` handles the declaration of C++ structs.
+- tests: contains the tests to each module in Numbast

--- a/numbast/README.md
+++ b/numbast/README.md
@@ -37,7 +37,7 @@ __device__ __myfloat16 hsqrt(const __myfloat16 a);
 |Kind|C++ Declaration|C++ Usage|Numba|Explanation|
 |---	|---	|---	|---	|---	|
 |Concrete functions|`__myfloat16 hsqrt(__myfloat16 a)`|`auto res = hsqrt(f)`|`res = hsqrt(f)`|Function (for all overloads) typing and lowering are generated.|
-|Operator overloads|``__myfloat16 operator+(const __myfloat16&, const __myfloat16&)``|`auto twof = f + f`|`twof = f + f`|Operators (for all overloads) typing and lowering are generated. Operators from C++ are mapped to its corresponding operation in Python, e.g. (`operator +` mapped to `operator.add` or `operator.pos` based on number of arguments.)|
+|Operator overloads|``__myfloat16 operator+(const __myfloat16&, const __myfloat16&)``|`auto twof = f + f`|`twof = f + f`|Operators (for all overloads) typing and lowering are generated. Operators from C++ are mapped to its corresponding operation in Python. e.g. `operator +` is mapped to `operator.add` or `operator.pos` based on number of arguments.|
 
 
 ### Requirement

--- a/numbast/README.md
+++ b/numbast/README.md
@@ -29,8 +29,8 @@ __device__ __myfloat16 hsqrt(const __myfloat16 a);
 |Kind|C++ Declaration|C++ Usage|Numba Usage|Explanation|
 |---	|---	|---	|---	|---	|
 |Concrete Struct Constructor|`__myfloat16(double val)`|`auto f = __myfloat16(3.14)`|`f = __myfloat16(3.14)`|A new Numba type for `Foo` is created; Struct data model for type `Foo` is created; Typings and lowerings for `Foo` constructors are also generated.|
-|Concrete Struct Conversion Operator|`operator float() {}`|`float x = float(f)`|`x = float(f)`|Conversion operators defined for `Foo` struct are generated.|
-|Concrete Struct Attribute|`half data;`|`auto data = f.data`|`data = f.data`|Public attributes for structs are accessible. Note: only read access is supported.|
+|Concrete Struct Conversion Operator|`operator float()`|`float x = float(f)`|`x = float(f)`|Conversion operators defined for `Foo` struct are generated.|
+|Concrete Struct Attribute|`half data`|`auto data = f.data`|`data = f.data`|Public attributes for structs are accessible. Note: only read access is supported.|
 
 ### Concrete Functions (e.g. `__myfloat16 hsqrt(__myfloat16 a)` or `__myfloat16 operator+(const __myfloat16&, const __myfloat16&)`)
 |Kind|C++ Declaration|C++ Usage|Numba|Explanation|


### PR DESCRIPTION
This PR adds readme to the Numbast module. Which is previously missing.
