### PR TITLE
Replace invalid `unique_ptr` copy initialization from a raw pointer with direct initialization

### DIFF
--- a/ast_canopy/cpp/src/ast_canopy.cpp
+++ b/ast_canopy/cpp/src/ast_canopy.cpp
@@ -62,8 +62,8 @@ parse_declarations_from_command_line(std::vector<std::string> options,
   auto Diags =
       CompilerInstance::createDiagnostics(&*DiagOpts, &*DiagConsumer, false);
 
-  std::unique_ptr<ASTUnit> ast = ASTUnit::LoadFromCommandLine(
-      argstart, argend, PCHContainerOps, Diags, "");
+  std::unique_ptr<ASTUnit> ast(ASTUnit::LoadFromCommandLine(
+      argstart, argend, PCHContainerOps, Diags, ""));
 
   Declarations decls;
   std::unordered_map<int64_t, std::string> record_id_to_name;


### PR DESCRIPTION
`unique_ptr`'s raw pointer constructor is explicit, so copy initialization will fail. See: C++ Standard [unique.ptr.single.ctor] https://eel.is/c++draft/unique.ptr.single.ctor#lib:unique_ptr,constructor_

Example of the issue: https://godbolt.org/z/3WrEY18T8

This happens with older versions of the Clang library, where `ASTUnit::LoadFromCommandLine` returns an `ASTUnit*` instead of a `unique_ptr<ASTUnit>`. 

https://github.com/NVIDIA/numbast/blob/main/ast_canopy/cpp/src/ast_canopy.cpp#L65-L66

I ran into this with Clang 16. In the latest versions of the Clang library, it does return a `unique_ptr`, so there's no issue.

https://clang.llvm.org/doxygen/classclang_1_1ASTUnit.html#a10bdfe1735fbb62b6c43decedb22c333

Direct initialization works fine for both versions.