### PR TITLE
Fixes bug where `types.void` is cast to `none` string and where static_binding_generator parses a None type from yaml

### DIFF
--- a/numbast/src/numbast/static/types.py
+++ b/numbast/src/numbast/static/types.py
@@ -10,6 +10,7 @@ from numbast.errors import TypeNotFoundError
 
 CTYPE_TO_NBTYPE_STR = {k: str(v) for k, v in CTYPE_MAPS.items()}
 CTYPE_TO_NBTYPE_STR["bool"] = "bool_"
+CTYPE_TO_NBTYPE_STR["void"] = "void"
 
 
 def register_enum_type_str(enum_name: str):

--- a/numbast/src/numbast/tools/static_binding_generator.py
+++ b/numbast/src/numbast/tools/static_binding_generator.py
@@ -344,6 +344,11 @@ def static_binding_generator(
             exclude_functions = excludes.get("Function", [])
             exclude_structs = excludes.get("Struct", [])
 
+            if exclude_functions is None:
+                exclude_functions = []
+            if exclude_structs is None:
+                exclude_structs = []
+
             _static_binding_generator(
                 input_header,
                 retain_list,


### PR DESCRIPTION
Fixes 2 bugs as the title suggests.