### PR TITLE
Raise Warning when Numbast Skips a Non-Device Function

### DIFF
--- a/numbast/src/numbast/function.py
+++ b/numbast/src/numbast/function.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from warnings import warn
 from collections import defaultdict
 
 from numba import types as nbtypes
@@ -248,6 +249,7 @@ def bind_cxx_function(
         execution_space.host_device,
     }:
         # Skip non device functions
+        warn(f"Skipped non device function {func_decl.name}.")
         return None
 
     if func_decl.is_overloaded_operator():

--- a/numbast/src/numbast/static/function.py
+++ b/numbast/src/numbast/static/function.py
@@ -6,6 +6,7 @@ from textwrap import indent
 from logging import getLogger, FileHandler
 import tempfile
 from collections import defaultdict
+from warnings import warn
 
 from numbast.static.renderer import BaseRenderer
 from numbast.static.types import to_numba_type_str
@@ -451,6 +452,7 @@ class {op_typing_name}(ConcreteTemplate):
                 execution_space.device,
                 execution_space.host_device,
             }:
+                warn(f"Skipping non-device function {decl.name} in {self._header_path}")
                 continue
 
             renderer = None


### PR DESCRIPTION
Numbast only parses device side functions, host side functions are currently skipped in silence. This PR adds a warning so that users gets an early warning.