### PR TITLE
Fix clang++ default header extraction command

### DIFF
--- a/ast_canopy/ast_canopy/api.py
+++ b/ast_canopy/ast_canopy/api.py
@@ -65,10 +65,19 @@ def get_default_compiler_search_paths() -> list[str]:
     Extract the default system header search paths from the logs and return them.
     """
 
-    # Alternatively, use `clang++ --print-search-dirs`
+    # clang++ needs to be put in cuda mode so that it can include the proper headers
     clang_compile_empty = (
         subprocess.check_output(
-            ["clang++", "-E", "-v", "-xc++", "/dev/null"], stderr=subprocess.STDOUT
+            [
+                "clang++",
+                "-fsyntax-only",
+                "-v",
+                "--cuda-device-only",
+                "--no-cuda-version-check",
+                "-xcuda",
+                "/dev/null",
+            ],
+            stderr=subprocess.STDOUT,
         )
         .decode()
         .strip()

--- a/ast_canopy/tests/data/noinline_macro_fix.cu
+++ b/ast_canopy/tests/data/noinline_macro_fix.cu
@@ -1,0 +1,7 @@
+// Without `cuda_wrappers/` include overrides in the clang++ include paths,
+// the below include will raise a error for the __noinline_ macro somewhere
+// in the call stack. See the error being discussed here:
+// https://github.com/NVIDIA/thrust/issues/1703
+// The fix is included in clang17+:
+// https://github.com/llvm/llvm-project-release-prs/pull/698/files
+#include <cooperative_groups/reduce.h>

--- a/ast_canopy/tests/data/noinline_macro_fix.cu
+++ b/ast_canopy/tests/data/noinline_macro_fix.cu
@@ -1,5 +1,5 @@
 // Without `cuda_wrappers/` include overrides in the clang++ include paths,
-// the below include will raise a error for the __noinline_ macro somewhere
+// the below include will raise a error for the __noinline__ macro somewhere
 // in the call stack. See the error being discussed here:
 // https://github.com/NVIDIA/thrust/issues/1703
 // The fix is included in clang17+:

--- a/ast_canopy/tests/test_noinline_fix.py
+++ b/ast_canopy/tests/test_noinline_fix.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 from contextlib import redirect_stdout

--- a/ast_canopy/tests/test_noinline_fix.py
+++ b/ast_canopy/tests/test_noinline_fix.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from contextlib import redirect_stdout
+from io import StringIO
+
+import pytest
+
+from ast_canopy import parse_declarations_from_source
+
+
+@pytest.fixture(scope="module")
+def sample_noinline_macro(data_folder):
+    return data_folder / "noinline_macro_fix.cu"
+
+
+def test_noinline_macro(sample_noinline_macro):
+    srcstr = str(sample_noinline_macro)
+
+    buf = StringIO()
+    with redirect_stdout(buf):
+        parse_declarations_from_source(srcstr, [srcstr], "sm_80", verbose=True)
+
+    assert "error: use of undeclared identifier 'noinline'" not in buf.getvalue()


### PR DESCRIPTION
This PR puts the default C++ header extraction command into clang++ cuda mode. This ensures that some patches for CUDA headers made by upstream clang are included.
