### PR TITLE
Hide shim function linkables behind typing/lowering pass, removes `c_ext_shim_func` variable

### DIFF
--- a/conda/recipes/numbast/meta.yaml
+++ b/conda/recipes/numbast/meta.yaml
@@ -38,7 +38,7 @@ requirements:
     - cuda-version >=12.5
     - numba >=0.59
     - python
-    - numba-cuda
+    - numba-cuda >=0.5.0
     - pynvjitlink >=0.2
     - pyyaml
     - click

--- a/conda/recipes/numbast_extensions/meta.yaml
+++ b/conda/recipes/numbast_extensions/meta.yaml
@@ -29,7 +29,7 @@ requirements:
     - cuda-cudart-dev
     - python
     - numba >=0.59
-    - numba-cuda
+    - numba-cuda >=0.5.0
     - numbast =={{ version }}
 
   test:

--- a/numbast/src/numbast/static/function.py
+++ b/numbast/src/numbast/static/function.py
@@ -42,12 +42,15 @@ class StaticFunctionRenderer(BaseRenderer):
 
     signature_template = "signature({return_type}, {param_types})"
 
+    shim_name_local = "shim"
+
     decl_device_template = """
 {decl_name} = declare_device(
     '{unique_shim_name}',
     {return_type}(
         {pointer_wrapped_param_types}
-    )
+    ),
+    link={shim_name_local}
 )
     """
 
@@ -56,21 +59,10 @@ def {caller_name}({nargs}):
     return {decl_name}({nargs})
     """
 
-    c_ext_shim_template = """
-extern "C" __device__ int
-{unique_shim_name}({return_type} &retval {arglist}) {{
-    retval = {func_name}({args});
-    return 0;
-}}
-    """
-
-    c_ext_shim_template_void_ret = """
-extern "C" __device__ int
-{unique_shim_name}(int &ignored {arglist}) {{
-    {func_name}({args});
-    return 0;
-}}
-    """
+    c_ext_shim_var_template = """
+shim_raw_str = \"\"\"{shim_rendered}\"\"\"
+{shim_name_local} = CUSource(shim_raw_str)
+"""
 
     lowering_template = """
 @lower({func_name}, {params})
@@ -87,9 +79,15 @@ def impl(context, builder, sig, args):
     )
 """
 
+    lowering_body_template = """
+{shim_var}
+{decl_device}
+{lowering}
+"""
+
     scoped_lowering_template = """
 def _{unique_function_name}_lower():
-    {body}
+{body}
 
 _{unique_function_name}_lower()
 """
@@ -173,6 +171,7 @@ def {func_name}():
             unique_shim_name=self._deduplicated_shim_name,
             return_type=self._return_numba_type_str,
             pointer_wrapped_param_types=self._pointer_wrapped_param_types_str,
+            shim_name_local=self.shim_name_local,
         )
 
         nargs = [f"arg_{i}" for i in range(len(self._decl.params))]
@@ -188,12 +187,19 @@ def {func_name}():
 
     def _render_shim_function(self):
         """Render external C shim functions for this struct constructor."""
+        self.Imports.add("from numba.cuda import CUSource")
 
         self._c_ext_shim_rendered = make_function_shim(
             shim_name=self._deduplicated_shim_name,
             func_name=self._decl.name,
             return_type=self._decl.return_type.unqualified_non_ref_type_name,
             params=self._decl.params,
+            includes=[self._header_path],
+        )
+
+        self._c_ext_shim_var_rendered = self.c_ext_shim_var_template.format(
+            shim_name_local=self.shim_name_local,
+            shim_rendered=self._c_ext_shim_rendered,
         )
 
         self.ShimFunctions.append(self._c_ext_shim_rendered)
@@ -224,11 +230,18 @@ def {func_name}():
         self._render_shim_function()
         self._render_lowering()
 
-        lower_body = indent(
-            self._decl_device_rendered + "\n" + self._lowering_rendered,
-            prefix="    ",
-            predicate=lambda x: True,
+        # lower_body = indent(
+        #     self._decl_device_rendered + "\n" + self._lowering_rendered,
+        #     prefix="    ",
+        #     predicate=lambda x: True,
+        # )
+
+        lower_body = self.lowering_body_template.format(
+            shim_var=self._c_ext_shim_var_rendered,
+            decl_device=self._decl_device_rendered,
+            lowering=self._lowering_rendered,
         )
+        lower_body = indent(lower_body, " " * 4)
 
         self._lower_rendered = self.scoped_lowering_template.format(
             unique_function_name=self._deduplicated_shim_name,
@@ -440,8 +453,6 @@ class {op_typing_name}(ConcreteTemplate):
 
     def _render(self, with_prefix: bool, with_imports: bool):
         """Render python bindings and shim functions."""
-        self.Imports.add("from numba.cuda import CUSource")
-
         for decl in self._decls:
             if decl.name in self._excludes:
                 continue
@@ -507,15 +518,16 @@ class {op_typing_name}(ConcreteTemplate):
 
         self._python_str += "\n" + "\n".join(python_rendered)
 
-        c_rendered = []
-        for c in self._c_rendered:
-            c_rendered.append(c)
+        # c_rendered = []
+        # for c in self._c_rendered:
+        #     c_rendered.append(c)
 
-        self._c_str = "\n".join(self.Includes) + "\n".join(c_rendered)
+        # self._c_str = "\n".join(self.Includes) + "\n".join(c_rendered)
 
-        self._shim_function_pystr = self.MemoryShimWriterTemplate.format(
-            shim_funcs=self._c_str
-        )
+        # self._shim_function_pystr = self.MemoryShimWriterTemplate.format(
+        #     shim_funcs=self._c_str
+        # )
+        self._shim_function_pystr = self._c_str = ""
 
     def render_as_str(
         self, *, with_prefix: bool, with_imports: bool, with_shim_functions: bool

--- a/numbast/src/numbast/static/function.py
+++ b/numbast/src/numbast/static/function.py
@@ -236,12 +236,6 @@ def _{unique_function_name}_lower():
         self._render_shim_function()
         self._render_lowering()
 
-        # lower_body = indent(
-        #     self._decl_device_rendered + "\n" + self._lowering_rendered,
-        #     prefix="    ",
-        #     predicate=lambda x: True,
-        # )
-
         lower_body = self.lowering_body_template.format(
             shim_var=self._c_ext_shim_var_rendered,
             decl_device=self._decl_device_rendered,
@@ -640,15 +634,6 @@ def {op_typing_name_overload}({arg_list}):
 
         self._python_str += "\n" + "\n".join(python_rendered)
 
-        # c_rendered = []
-        # for c in self._c_rendered:
-        #     c_rendered.append(c)
-
-        # self._c_str = "\n".join(self.Includes) + "\n".join(c_rendered)
-
-        # self._shim_function_pystr = self.MemoryShimWriterTemplate.format(
-        #     shim_funcs=self._c_str
-        # )
         self._shim_function_pystr = self._c_str = ""
 
     def render_as_str(

--- a/numbast/src/numbast/static/renderer.py
+++ b/numbast/src/numbast/static/renderer.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import warnings
+
 import numba
 from numba.cuda.vector_types import vector_types
 
@@ -9,7 +11,7 @@ class BaseRenderer:
     Prefix = """
 import numba
 numba.config.CUDA_ENABLE_PYNVJITLINK = True
-"""
+"""  # Code that precedes the first import line.
 
     Imports: set[str] = set()
     """One element stands for one line of python import."""
@@ -38,24 +40,6 @@ c_ext_shim_source = CUSource(\"""{shim_funcs}\""")
     def __init__(self, decl):
         self._decl = decl
 
-    def _render_typing(self):
-        pass
-
-    def _render_data_model(self):
-        pass
-
-    def _render_lowering(self):
-        pass
-
-    def _render_decl_device(self):
-        pass
-
-    def _render_shim_function(self, decl):
-        pass
-
-    def _render_python_api(self):
-        pass
-
     @classmethod
     def _try_import_numba_type(cls, typ: str):
         if typ in cls._imported_numba_types:
@@ -70,6 +54,8 @@ c_ext_shim_source = CUSource(\"""{shim_funcs}\""")
         if typ in numba.types.__dict__:
             cls.Imports.add(f"from numba.types import {typ}")
             cls._imported_numba_types.add(typ)
+
+        warnings.warn(f"{typ} is not added to imports.")
 
     def render_as_str(
         self, *, with_prefix: bool, with_imports: bool, with_shim_functions: bool

--- a/numbast/src/numbast/static/tests/conftest.py
+++ b/numbast/src/numbast/static/tests/conftest.py
@@ -10,4 +10,7 @@ import os
 def data_folder():
     current_directory = os.path.dirname(os.path.abspath(__file__))
 
-    return lambda file: os.path.join(current_directory, "data/", file)
+    def get_data_file(*file):
+        return os.path.join(current_directory, "data/", *file)
+
+    return get_data_file

--- a/numbast/src/numbast/static/tests/data/function.cuh
+++ b/numbast/src/numbast/static/tests/data/function.cuh
@@ -3,15 +3,17 @@
 // SPDX-License-Identifier: Apache-2.0
 // clang-format on
 
+#pragma once
+
 // Overloaded functions
-int __device__ add(int a, int b) { return a + b; }
-float __device__ add(float a, float b) { return a + b; }
+int __device__ add(int a, int b);
+float __device__ add(float a, float b);
 
 // Different types
-int __device__ minus_i32_f32(int a, float b) { return a - static_cast<int>(b); }
+int __device__ minus_i32_f32(int a, float b);
 
 // void return type
-void __device__ set_42(int *val) {
-  *val = 42;
-  return;
-}
+void __device__ set_42(int *val);
+
+// operator overload on numba-cuda specific type (float2)
+float2 __device__ operator+(const float2 &a, const float2 &b);

--- a/numbast/src/numbast/static/tests/data/src/function.cu
+++ b/numbast/src/numbast/static/tests/data/src/function.cu
@@ -1,0 +1,18 @@
+// clang-format off
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// clang-format on
+
+int __device__ add(int a, int b) { return a + b; }
+float __device__ add(float a, float b) { return a + b; }
+
+int __device__ minus_i32_f32(int a, float b) { return a - static_cast<int>(b); }
+
+void __device__ set_42(int *val) {
+  *val = 42;
+  return;
+}
+
+float2 __device__ operator+(const float2 &a, const float2 &b) {
+  return {a.x + b.x, a.y + b.y};
+}

--- a/numbast/src/numbast/static/tests/data/src/operator.cu
+++ b/numbast/src/numbast/static/tests/data/src/operator.cu
@@ -3,13 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // clang-format on
 
-struct Foo {
-public:
-  int x;
+#include "operator.cuh"
 
-  __device__ Foo();
-  __device__ Foo(int x);
-};
+Foo::Foo() {}
+Foo::Foo(int x) : x(x) {}
 
-// Overloaded functions
-Foo __device__ operator+(const Foo &lhs, const Foo &rhs);
+Foo __device__ operator+(const Foo &lhs, const Foo &rhs) {
+  return Foo(lhs.x + rhs.x);
+}

--- a/numbast/src/numbast/static/tests/test_function_static_bindings.py
+++ b/numbast/src/numbast/static/tests/test_function_static_bindings.py
@@ -10,30 +10,28 @@ from numba.types import int32, float32
 from numba import cuda
 from numba.cuda import device_array
 
-
+from ast_canopy import parse_declarations_from_source
 from numbast.static.renderer import clear_base_renderer_cache
+from numbast.static.function import StaticFunctionsRenderer
 
 
 @pytest.fixture(scope="module")
 def decl(data_folder):
     clear_base_renderer_cache()
 
-    # header = data_folder("function.cuh")
+    header = data_folder("function.cuh")
 
-    # decls = parse_declarations_from_source(header, [header], "sm_50")
-    # functions = decls.functions
+    decls = parse_declarations_from_source(header, [header], "sm_50")
+    functions = decls.functions
 
-    # assert len(functions) == 5
+    assert len(functions) == 5
 
-    # SFR = StaticFunctionsRenderer(functions, header)
+    SFR = StaticFunctionsRenderer(functions, header)
 
-    # bindings = SFR.render_as_str(
-    #     with_prefix=True, with_imports=True, with_shim_functions=True
-    # )
+    bindings = SFR.render_as_str(
+        with_prefix=True, with_imports=True, with_shim_functions=True
+    )
     globals = {}
-
-    with open("bindings.py", "r") as f:
-        bindings = f.read()
 
     exec(bindings, globals)
 

--- a/numbast/src/numbast/static/tests/test_function_static_bindings.py
+++ b/numbast/src/numbast/static/tests/test_function_static_bindings.py
@@ -44,7 +44,6 @@ def decl(data_folder):
 @pytest.fixture(scope="module")
 def impl(data_folder):
     impl = data_folder("src", "function.cu")
-    print(impl)
     return impl
 
 

--- a/numbast/src/numbast/static/tests/test_operator_bindings.py
+++ b/numbast/src/numbast/static/tests/test_operator_bindings.py
@@ -11,7 +11,7 @@ from numba.cuda import device_array
 
 from ast_canopy import parse_declarations_from_source
 
-from numbast.static.renderer import get_rendered_imports, get_rendered_shims, get_prefix
+from numbast.static.renderer import get_rendered_imports, get_prefix
 from numbast.static.renderer import clear_base_renderer_cache
 from numbast.static.struct import StaticStructsRenderer
 from numbast.static.function import StaticFunctionsRenderer
@@ -42,13 +42,7 @@ def cuda_decls(data_folder):
     )
 
     bindings = "\n".join(
-        [
-            get_prefix(),
-            get_rendered_imports(),
-            struct_bindings,
-            function_bindings,
-            get_rendered_shims(),
-        ]
+        [get_prefix(), get_rendered_imports(), struct_bindings, function_bindings]
     )
 
     globals = {}

--- a/numbast/src/numbast/tools/static_binding_generator.py
+++ b/numbast/src/numbast/tools/static_binding_generator.py
@@ -19,7 +19,6 @@ from pylibastcanopy import Enum, Typedef
 from numbast.static import reset_renderer
 from numbast.static.renderer import (
     get_prefix,
-    get_rendered_shims,
     get_rendered_imports,
 )
 from numbast.static.struct import StaticStructsRenderer
@@ -308,7 +307,6 @@ def _static_binding_generator(
 
     prefix_str = get_prefix()
     imports_str = get_rendered_imports()
-    shim_function_str = get_rendered_shims()
 
     # Example: Save the processed output to the output directory
     output_file = os.path.join(output_dir, f"{basename}.py")
@@ -328,8 +326,6 @@ def _static_binding_generator(
 {function_bindings}
 # Aliases:
 {rendered_aliases}
-# Shim functions:
-{shim_function_str}
 """
 
     with open(output_file, "w") as file:

--- a/numbast/src/numbast/utils.py
+++ b/numbast/src/numbast/utils.py
@@ -71,6 +71,7 @@ def make_function_shim(
     func_name: str,
     return_type: str,
     params: list[pylibastcanopy.ParamVar],
+    includes: list[str] = [],
 ) -> str:
     """Create a function shim layer template.
 
@@ -84,6 +85,8 @@ def make_function_shim(
         The return type of the function.
     params : list[pylibastcanopy.ParamVar]
         The parameters of the function.
+    includes : list[str]
+        The list of header paths to be included to the shim.
 
     Returns
     -------
@@ -141,5 +144,9 @@ extern "C" __device__ int
         retval=retval,
         actual_args=acutal_args_str,
     )
+
+    include_str = "\n".join([f"#include <{include}>" for include in includes])
+
+    shim = include_str + shim
 
     return shim

--- a/numbast_extensions/tests/static/test_static_bf16.py
+++ b/numbast_extensions/tests/static/test_static_bf16.py
@@ -18,7 +18,6 @@ from numbast.tools.static_binding_generator import _typedef_to_aliases
 from numbast.static.typedef import render_aliases
 from numbast.static.renderer import (
     get_prefix,
-    get_rendered_shims,
     get_rendered_imports,
 )
 
@@ -67,7 +66,6 @@ def bfloat16():
 
     prefix_str = get_prefix()
     imports_str = get_rendered_imports()
-    shim_function_str = get_rendered_shims()
 
     bindings = f"""
 {prefix_str}
@@ -75,7 +73,6 @@ def bfloat16():
 {struct_bindings}
 {function_bindings}
 {typedef_bindings}
-{shim_function_str}
 """
 
     globals = {}

--- a/numbast_extensions/tests/static/test_static_fp16.py
+++ b/numbast_extensions/tests/static/test_static_fp16.py
@@ -18,7 +18,6 @@ from numbast.tools.static_binding_generator import _typedef_to_aliases
 from numbast.static.typedef import render_aliases
 from numbast.static.renderer import (
     get_prefix,
-    get_rendered_shims,
     get_rendered_imports,
 )
 
@@ -73,7 +72,6 @@ def float16():
 
     prefix_str = get_prefix()
     imports_str = get_rendered_imports()
-    shim_function_str = get_rendered_shims()
 
     bindings = f"""
 {prefix_str}
@@ -81,7 +79,6 @@ def float16():
 {struct_bindings}
 {function_bindings}
 {typedef_bindings}
-{shim_function_str}
 """
 
     globals = {}


### PR DESCRIPTION
Numba_cuda introduced a new way to auto link external functions to declared functions in Numba. Numbast leverages this new mechanism to auto link shim functions, hiding away its linkage from user API.

Currently failing with linker error: `undefined reference to add_1 in <unnamed-ptx>`