### PR TITLE
Add Support to `isinstance` Type Check to New Types

### DIFF
--- a/conda/recipes/ast_canopy/meta.yaml
+++ b/conda/recipes/ast_canopy/meta.yaml
@@ -49,7 +49,7 @@ requirements:
     - pybind11
     - pip
     - scikit-build-core
-    - clangdev >=18
+    - clangdev ==18
     - llvmdev >=14
     - llvm >=14
   run:

--- a/conda/recipes/ast_canopy/meta.yaml
+++ b/conda/recipes/ast_canopy/meta.yaml
@@ -56,7 +56,7 @@ requirements:
     - cuda-version >=12.5
     - cuda-nvcc >=12.5
     - python
-    - clangdev >=18
+    - clangdev ==18
 
 about:
   license_family: Apache

--- a/conda/recipes/ast_canopy/meta.yaml
+++ b/conda/recipes/ast_canopy/meta.yaml
@@ -49,14 +49,14 @@ requirements:
     - pybind11
     - pip
     - scikit-build-core
-    - clangdev ==18
+    - clangdev >=18,<19
     - llvmdev >=14
     - llvm >=14
   run:
     - cuda-version >=12.5
     - cuda-nvcc >=12.5
     - python
-    - clangdev ==18
+    - clangdev >=18,<19
 
 about:
   license_family: Apache

--- a/numbast/src/numbast/static/struct.py
+++ b/numbast/src/numbast/static/struct.py
@@ -626,8 +626,6 @@ class {struct_type_class_name}({parent_type}):
     python_api_template = """
 # Make Python API for struct
 {struct_name} = type("{struct_name}", (), {{"_nbtype": {struct_type_name}}})
-
-as_numba_type.register({struct_name}, {struct_type_name})
 """
 
     primitive_data_model_template = """
@@ -726,8 +724,6 @@ class {struct_attr_typing_name}(AttributeTemplate):
 
         This is the python handle to use it in Numba kernels.
         """
-        self.Imports.add("from numba.extending import as_numba_type")
-
         self._python_api_rendered = self.python_api_template.format(
             struct_type_name=self._struct_type_name, struct_name=self._struct_name
         )

--- a/numbast/src/numbast/static/struct.py
+++ b/numbast/src/numbast/static/struct.py
@@ -626,6 +626,8 @@ class {struct_type_class_name}({parent_type}):
     python_api_template = """
 # Make Python API for struct
 {struct_name} = type("{struct_name}", (), {{"_nbtype": {struct_type_name}}})
+
+as_numba_type.register({struct_name}, {struct_type_name})
 """
 
     primitive_data_model_template = """
@@ -724,6 +726,8 @@ class {struct_attr_typing_name}(AttributeTemplate):
 
         This is the python handle to use it in Numba kernels.
         """
+        self.Imports.add("from numba.extending import as_numba_type")
+
         self._python_api_rendered = self.python_api_template.format(
             struct_type_name=self._struct_type_name, struct_name=self._struct_name
         )

--- a/numbast/src/numbast/static/tests/test_struct_static_bindings.py
+++ b/numbast/src/numbast/static/tests/test_struct_static_bindings.py
@@ -101,3 +101,21 @@ def test_myint_cast(cuda_struct, numbast_jit):
     arr = device_array((1,), "int32")
     kernel[1, 1](arr)
     assert arr.copy_to_host() == pytest.approx([42])
+
+
+def test_static_type_check(decl, impl):
+    MyInt = decl["MyInt"]
+
+    from numba.types import int32
+
+    @cuda.jit(link=[impl])
+    def kernel(arr):
+        i = MyInt(42)
+        if isinstance(i, MyInt):
+            arr[0] = int32(i)
+        else:
+            arr[0] = 0
+
+    arr = device_array((1,), "int32")
+    kernel[1, 1](arr)
+    assert arr.copy_to_host() == pytest.approx([42])

--- a/numbast/src/numbast/static/tests/test_struct_static_bindings.py
+++ b/numbast/src/numbast/static/tests/test_struct_static_bindings.py
@@ -101,21 +101,3 @@ def test_myint_cast(cuda_struct, numbast_jit):
     arr = device_array((1,), "int32")
     kernel[1, 1](arr)
     assert arr.copy_to_host() == pytest.approx([42])
-
-
-def test_static_type_check(decl, impl):
-    MyInt = decl["MyInt"]
-
-    from numba.types import int32
-
-    @cuda.jit(link=[impl])
-    def kernel(arr):
-        i = MyInt(42)
-        if isinstance(i, MyInt):
-            arr[0] = int32(i)
-        else:
-            arr[0] = 0
-
-    arr = device_array((1,), "int32")
-    kernel[1, 1](arr)
-    assert arr.copy_to_host() == pytest.approx([42])


### PR DESCRIPTION
The use of `isinstance` is a static type check at compile time. Adding `as_numba_type` helps Numba resolving the python struct handle to the newly created Numba type. As is shown here: https://numba.readthedocs.io/en/stable/reference/types.html?highlight=as_numba_type#numba.extending.as_numba_type