### PR TITLE
Add Structure to Track Instantiation Args for Templates

### DIFF
--- a/ast_canopy/ast_canopy/api.py
+++ b/ast_canopy/ast_canopy/api.py
@@ -13,7 +13,7 @@ from numba.cuda.cuda_paths import get_nvidia_nvvm_ctk, get_cuda_home
 
 import pylibastcanopy as bindings
 
-from ast_canopy.decl import Function, Struct, ClassTemplate
+from ast_canopy.decl import Function, Struct, FunctionTemplate, ClassTemplate
 from ast_canopy.fdcap_min import capture_fd, STREAMFD
 
 logger = logging.getLogger(f"AST_Canopy.{__name__}")
@@ -23,7 +23,7 @@ logger = logging.getLogger(f"AST_Canopy.{__name__}")
 class Declarations:
     structs: list[Struct]
     functions: list[Function]
-    function_templates: list[bindings.FunctionTemplate]
+    function_templates: list[FunctionTemplate]
     class_templates: list[ClassTemplate]
     typedefs: list[bindings.Typedef]
     enums: list[bindings.Enum]
@@ -148,14 +148,7 @@ def parse_declarations_from_source(
     additional_includes: list[str] = [],
     anon_filename_decl_prefix_allowlist: list[str] = [],
     verbose: bool = False,
-) -> tuple[
-    list[Struct],
-    list[Function],
-    list[bindings.FunctionTemplate],
-    list[ClassTemplate],
-    list[bindings.Typedef],
-    list[bindings.Enum],
-]:
+) -> Declarations:
     """Given a source file, parse all *top-level* declarations from it.
     Returns a tuple that each contains a list of declaration objects for the source file.
 
@@ -200,9 +193,7 @@ def parse_declarations_from_source(
 
     Returns
     -------
-    tuple:
-        A tuple containing lists of declaration objects from the source file.
-        See decl.py and pylibastcanopy.pyi for the declaration object types.
+    Declarations: See `Declarations` struct definition for detail.
     """
 
     if not os.path.exists(source_file_path):
@@ -280,6 +271,9 @@ def parse_declarations_from_source(
 
     structs = [Struct.from_c_obj(c_obj) for c_obj in decls.records]
     functions = [Function.from_c_obj(c_obj) for c_obj in decls.functions]
+    function_templates = [
+        FunctionTemplate.from_c_obj(c_obj) for c_obj in decls.function_templates
+    ]
     class_templates = [
         ClassTemplate.from_c_obj(c_obj) for c_obj in decls.class_templates
     ]
@@ -287,7 +281,7 @@ def parse_declarations_from_source(
     return Declarations(
         structs,
         functions,
-        decls.function_templates,
+        function_templates,
         class_templates,
         decls.typedefs,
         decls.enums,

--- a/ast_canopy/ast_canopy/instantiations.py
+++ b/ast_canopy/ast_canopy/instantiations.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import ast_canopy
+
+
+# TODO: POC only, ideally this logic should be implemented in libastcanopy
+# The python binding provides python type - CXX type conversion
+class BaseInstantiation:
+    """Indicates a instantiation of a template"""
+
+    def __init__(self, template: "ast_canopy.decl.Template"):
+        self.template_parameters = template.template_parameters
+        self._template_param_names = [
+            tparam.name for tparam in self.template_parameters
+        ]
+
+    def instantiate(self, **kwargs):
+        self.instantiated_args = kwargs
+        self.validate()
+        return self
+
+    def validate(self):
+        if any(key not in self._template_param_names for key in self.instantiated_args):
+            raise ValueError(
+                f"Invalid template parameter names: {self.instantiated_args.keys()}, allowed template parameter names: {self._template_param_names}"
+            )
+        pass
+
+    @property
+    def param_list(self):
+        return [
+            self.instantiated_args[tparam.name] for tparam in self.template_parameters
+        ]
+
+    def get_instantiated_c_stmt(self) -> str:
+        name = self.name
+        param_list = self.param_list
+
+        flatten = []
+        for param in param_list:
+            if isinstance(param, BaseInstantiation):
+                flatten.append(param.get_instantiated_c_stmt())
+            else:
+                flatten.append(str(param))
+
+        param_list = ", ".join(flatten)
+        return f"{name}<{param_list}>"
+
+
+class FunctionInstantiation(BaseInstantiation):
+    """Indicates an instantiation of a function template"""
+
+    def __init__(self, function_template: "ast_canopy.decl.FunctionTemplate"):
+        super().__init__(function_template)
+        self.function = function_template.function
+
+    @property
+    def name(self):
+        return self.function.name
+
+
+class ClassInstantiation(BaseInstantiation):
+    """Indicates an instantiation of a class template"""
+
+    def __init__(self, class_template: "ast_canopy.decl.ClassTemplate"):
+        super().__init__(class_template)
+        self.record = class_template.record
+
+    @property
+    def name(self):
+        return self.record.name

--- a/ast_canopy/ast_canopy/pylibastcanopy.cpp
+++ b/ast_canopy/ast_canopy/pylibastcanopy.cpp
@@ -157,7 +157,9 @@ PYBIND11_MODULE(pylibastcanopy, m) {
           }));
 
   py::class_<Template>(m, "Template")
+      .def(py::init<std::vector<TemplateParam>, std::size_t>())
       .def_readwrite("template_parameters", &Template::template_parameters)
+      .def_readwrite("num_min_required_args", &Template::num_min_required_args)
       .def(py::pickle(
           [](const Template &t) {
             return py::make_tuple(t.template_parameters,

--- a/ast_canopy/tests/data/sample_constexpr_function_template.cu
+++ b/ast_canopy/tests/data/sample_constexpr_function_template.cu
@@ -1,0 +1,7 @@
+template <unsigned N> struct foo_t {
+  static __device__ constexpr unsigned size = N;
+};
+
+template <class TA, class TB> constexpr __device__ unsigned smem(TA t0, TB t1) {
+  return TA::size + TB::size;
+}

--- a/ast_canopy/tests/test_instantiation.py
+++ b/ast_canopy/tests/test_instantiation.py
@@ -1,0 +1,57 @@
+import os
+
+import pytest
+
+from ast_canopy import parse_declarations_from_source
+
+
+@pytest.fixture(scope="module")
+def sample_constexpr_function_template():
+    current_directory = os.path.dirname(os.path.abspath(__file__))
+    return os.path.join(
+        current_directory, "data/", "sample_constexpr_function_template.cu"
+    )
+
+
+@pytest.fixture(scope="module")
+def decls(sample_constexpr_function_template):
+    return parse_declarations_from_source(
+        sample_constexpr_function_template,
+        [sample_constexpr_function_template],
+        "sm_80",
+    )
+
+
+@pytest.fixture(scope="module")
+def foo_t(decls):
+    assert len(decls.class_templates) == 1
+    return decls.class_templates[0]
+
+
+@pytest.fixture(scope="module")
+def smem(decls):
+    assert len(decls.function_templates) == 1
+    return decls.function_templates[0]
+
+
+def test_instantiation(foo_t, smem):
+    foo_t_one = foo_t.instantiate(N=1)
+    foo_t_two = foo_t.instantiate(N=2)
+
+    smem_three = smem.instantiate(TA=foo_t_one, TB=foo_t_two)
+    smem_three_2 = smem.instantiate(TB=foo_t_two, TA=foo_t_one)
+
+    assert foo_t_one.get_instantiated_c_stmt() == "foo_t<1>"
+    assert foo_t_two.get_instantiated_c_stmt() == "foo_t<2>"
+    assert smem_three.get_instantiated_c_stmt() == "smem<foo_t<1>, foo_t<2>>"
+    assert smem_three_2.get_instantiated_c_stmt() == "smem<foo_t<1>, foo_t<2>>"
+
+
+def test_invalid_func_tparam_name(smem):
+    with pytest.raises(ValueError):
+        smem.instantiate(X=3.14)
+
+
+def test_invalid_cls_tparam_name(foo_t):
+    with pytest.raises(ValueError):
+        foo_t.instantiate(X=3.14)

--- a/ast_canopy/tests/test_parse_constexpr_function_template.py
+++ b/ast_canopy/tests/test_parse_constexpr_function_template.py
@@ -1,0 +1,40 @@
+import os
+
+import pytest
+
+from ast_canopy import parse_declarations_from_source
+from pylibastcanopy import template_param_kind
+
+
+@pytest.fixture(scope="module")
+def sample_constexpr_function_template():
+    current_directory = os.path.dirname(os.path.abspath(__file__))
+    return os.path.join(
+        current_directory, "data/", "sample_constexpr_function_template.cu"
+    )
+
+
+def test_parse_constexpr_function_template(sample_constexpr_function_template):
+    decls = parse_declarations_from_source(
+        sample_constexpr_function_template,
+        [sample_constexpr_function_template],
+        "sm_80",
+    )
+
+    func_temp = decls.function_templates
+    class_temp = decls.class_templates
+
+    assert len(func_temp) == 1
+    assert len(class_temp) == 1
+
+    assert func_temp[0].function.name == "smem"
+    assert len(func_temp[0].template_parameters) == 2
+    assert func_temp[0].template_parameters[0].name == "TA"
+    assert func_temp[0].template_parameters[0].kind == template_param_kind.type_
+    assert func_temp[0].template_parameters[1].name == "TB"
+    assert func_temp[0].template_parameters[1].kind == template_param_kind.type_
+
+    assert class_temp[0].record.name == "foo_t"
+    assert len(class_temp[0].template_parameters) == 1
+    assert class_temp[0].template_parameters[0].name == "N"
+    assert class_temp[0].template_parameters[0].kind == template_param_kind.non_type


### PR DESCRIPTION
This PR adds `Instantiation` class, this allows ast_canopy to track instantiated templates from python.