### PR TITLE
Use Single Upload Job for CondaBuild

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,19 +10,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-release
   cancel-in-progress: true
 jobs:
-  build-conda-x86_64:
+  build-conda:
     uses: ./.github/workflows/conda-python-build.yaml
     secrets: inherit
     with:
-      build_type: branch
+      build_type: release
       script: "ci/build_conda_python.sh"
-      CPU: "amd64"
-      upload_to_conda: true
-  build-conda-aarch64:
-    uses: ./.github/workflows/conda-python-build.yaml
-    secrets: inherit
-    with:
-      build_type: branch
-      script: "ci/build_conda_python.sh"
-      CPU: "arm64"
       upload_to_conda: true


### PR DESCRIPTION
We have two jobs in publish workflow currently. Each build to the same set of targets: `py3.10-3.13` x `aarch64/amd64`. As it turns out that the `CPU` field has no effect to the build. If we run the publish job, it builds the same targets twic. On upload, it runs into duplicate artifact conflicts: https://github.com/NVIDIA/numbast/actions/runs/14845380294/job/41677954654.

This PR removes one of the job and only use the amd64 instance to build for all targets.