### PR TITLE
Add CTPSD matcher, WAR nested `RecordDecl`

### DIFF
--- a/ast_canopy/cpp/CMakeLists.txt
+++ b/ast_canopy/cpp/CMakeLists.txt
@@ -34,7 +34,8 @@ add_library(astcanopy SHARED
             src/detail/matchers/function_template_matcher.cpp
             src/detail/matchers/class_template_matcher.cpp
             src/detail/matchers/enum_matcher.cpp
-            src/detail/matchers/constexpr_vardecl_matcher.cpp)
+            src/detail/matchers/constexpr_vardecl_matcher.cpp
+            src/detail/matchers/class_template_partial_specialization_matcher.cpp)
 
 # Define the public headers for astcanopy here.
 target_sources(astcanopy

--- a/ast_canopy/cpp/src/ast_canopy.cpp
+++ b/ast_canopy/cpp/src/ast_canopy.cpp
@@ -83,8 +83,10 @@ Declarations parse_declarations_from_command_line(
 
   Declarations decls;
   std::unordered_map<int64_t, std::string> record_id_to_name;
+  std::unordered_set<int64_t> record_id_with_ctpsd_ancestor;
   detail::traverse_ast_payload payload{&decls, &record_id_to_name,
-                                       &files_to_retain, &whitelist_prefixes};
+                                       &files_to_retain, &whitelist_prefixes,
+                                       &record_id_with_ctpsd_ancestor};
 
   detail::FunctionCallback func_callback(&payload);
   detail::RecordCallback record_callback(&payload);
@@ -92,8 +94,12 @@ Declarations parse_declarations_from_command_line(
   detail::FunctionTemplateCallback func_template_callback(&payload);
   detail::ClassTemplateCallback class_template_callback(&payload);
   detail::EnumCallback enum_callback(&payload);
+  detail::ClassTemplatePartialSpecializationCallback ctpsd_callback(&payload);
 
   MatchFinder finder;
+
+  finder.addMatcher(classTemplatePartialSpecializationDecl().bind("ctpsd"),
+                    &ctpsd_callback);
 
   // Match all free standing, non template functions.
   finder.addMatcher(

--- a/ast_canopy/cpp/src/detail/matchers.hpp
+++ b/ast_canopy/cpp/src/detail/matchers.hpp
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include <clang/ASTMatchers/ASTMatchFinder.h>
@@ -26,6 +27,9 @@ struct traverse_ast_payload {
   std::unordered_map<int64_t, std::string> *record_id_to_name;
   std::vector<std::string> *files_to_retain;
   std::vector<std::string> *prefixes_to_whitelist;
+  // The set of record IDs that has ClassTemplatePartialSpecializationDecl in
+  // ancestor
+  std::unordered_set<int64_t> *record_id_with_ctpsd_ancestor;
 };
 
 struct vardecl_matcher_payload {
@@ -96,6 +100,16 @@ public:
 
 private:
   vardecl_matcher_payload *payload;
+};
+
+class ClassTemplatePartialSpecializationCallback
+    : public MatchFinder::MatchCallback {
+public:
+  ClassTemplatePartialSpecializationCallback(traverse_ast_payload *);
+  void run(const MatchFinder::MatchResult &) override;
+
+private:
+  traverse_ast_payload *payload;
 };
 
 } // namespace detail

--- a/ast_canopy/cpp/src/detail/matchers/class_template_partial_specialization_matcher.cpp
+++ b/ast_canopy/cpp/src/detail/matchers/class_template_partial_specialization_matcher.cpp
@@ -1,0 +1,72 @@
+// clang-format off
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// clang-format on
+
+#include "matchers.hpp"
+
+#include <clang/AST/ASTContext.h>
+#include <clang/AST/RecursiveASTVisitor.h>
+
+#ifndef NDEBUG
+#include <iostream>
+#endif
+
+namespace ast_canopy {
+
+namespace detail {
+
+using namespace clang;
+
+class CXXRecordDeclInCTPSDVisitor
+    : public RecursiveASTVisitor<CXXRecordDeclInCTPSDVisitor> {
+public:
+  explicit CXXRecordDeclInCTPSDVisitor(
+      ASTContext *Context,
+      std::unordered_set<int64_t> *record_id_with_ctpsd_ancestor)
+      : Context(Context),
+        record_id_with_ctpsd_ancestor(record_id_with_ctpsd_ancestor) {}
+
+  bool VisitCXXRecordDecl(CXXRecordDecl *Decl) {
+    if (Decl->isThisDeclarationADefinition()) {
+      int64_t ID = Decl->getID();
+      record_id_with_ctpsd_ancestor->insert(ID);
+    }
+    return true; // Continue traversal
+  }
+
+private:
+  ASTContext *Context;
+  std::unordered_set<int64_t> *record_id_with_ctpsd_ancestor;
+};
+
+ClassTemplatePartialSpecializationCallback::
+    ClassTemplatePartialSpecializationCallback(traverse_ast_payload *payload)
+    : payload(payload) {}
+
+void ClassTemplatePartialSpecializationCallback::run(
+    const MatchFinder::MatchResult &Result) {
+  const ClassTemplatePartialSpecializationDecl *CTPSD =
+      Result.Nodes.getNodeAs<clang::ClassTemplatePartialSpecializationDecl>(
+          "ctpsd");
+  std::string file_name = source_filename_from_decl(CTPSD);
+
+  if (std::any_of(payload->files_to_retain->begin(),
+                  payload->files_to_retain->end(),
+                  [&file_name](const std::string &file_to_retain) {
+                    return file_name == file_to_retain;
+                  }))
+
+  {
+    ASTContext &ctx = CTPSD->getASTContext();
+    CXXRecordDeclInCTPSDVisitor visitor(&ctx,
+                                        payload->record_id_with_ctpsd_ancestor);
+    ClassTemplatePartialSpecializationDecl *CTPSD_ =
+        const_cast<ClassTemplatePartialSpecializationDecl *>(CTPSD);
+    visitor.TraverseDecl(CTPSD_);
+  }
+}
+
+} // namespace detail
+
+} // namespace ast_canopy

--- a/ast_canopy/cpp/src/detail/matchers/record_matcher.cpp
+++ b/ast_canopy/cpp/src/detail/matchers/record_matcher.cpp
@@ -35,6 +35,15 @@ void RecordCallback::run(const MatchFinder::MatchResult &Result) {
       // size.
       auto id = RD->getID();
 
+      // WAR: since
+      // unless(hasAncestor(classTemplatePartialSpecializationDecl())) is not
+      // functioning, we implemented a custom traversal in CTPSD matcher to log
+      // all recordDecl. For any recordDecl that showed up inside CTPSD, we skip
+      // them, as they are not top level decl.
+      auto skip_set = payload->record_id_with_ctpsd_ancestor;
+      if (skip_set->find(id) != skip_set->end())
+        return;
+
       // Anonymous structs, such as struct { int a; } X; is named as
       // "unnamed<ID>". This behavior is not persistent.
       std::string name = RD->getNameAsString();

--- a/ast_canopy/tests/data/sample_ctpsd.cu
+++ b/ast_canopy/tests/data/sample_ctpsd.cu
@@ -1,0 +1,3 @@
+template <typename A, typename B> struct foo {};
+
+template <typename T> struct foo<T, T *> {};

--- a/ast_canopy/tests/test_ctpsd.py
+++ b/ast_canopy/tests/test_ctpsd.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from ast_canopy import parse_declarations_from_source
+
+
+@pytest.fixture(scope="module")
+def sample_ctpsd(data_folder):
+    return data_folder / "sample_ctpsd.cu"
+
+
+def test_ctpsd_unparsed_in_structs(sample_ctpsd):
+    srcstr = str(sample_ctpsd)
+
+    decls = parse_declarations_from_source(srcstr, [srcstr], "sm_80")
+    ct = decls.class_templates
+
+    # At this stage, assert that the ctpsd is not parsed.
+    assert len(ct) == 1
+    assert ct[0].record.name == "foo"
+    assert len(ct[0].template_parameters) == 2


### PR DESCRIPTION
Due to an upstream ASTMatcher bug: 
https://github.com/llvm/llvm-project/issues/138782#issuecomment-2856591256

We cannot reliably skip matching nested `RecordDecl` inside a `ClassTemplateParitialSpecializationDecl` node. And since invoking `getTypeSize` on an uninstantiated record is generally a bad idea, (in fact, it leads to infinite recursion currently). We use a WAR to skip parsing any nested `RecordDecl` that exists inside a `CTPSD` node. It works like this:

Make a CTPSD matcher that precedes all existing matcher. When we matched a CTPSD node, use a separate `RecursiveASTVisitor` to traverse this node and collect all `RecordDecl` from within. Memoize all `RecordDecl` ID in the payload. When the matcher matches a `RecordDecl`, check if its ID is within the memoization. If it is, skip parsing this node.

Proper CTPSD handling will be added in a future PR.