### PR TITLE
Allow Custom Binding Name Specified via YAML

### DIFF
--- a/numbast/src/numbast/tools/static_binding_generator.py
+++ b/numbast/src/numbast/tools/static_binding_generator.py
@@ -314,7 +314,7 @@ def _static_binding_generator(
     - exclude_structs (list[str]): List of struct names to exclude from the bindings.
     - clang_include_paths (list[str]): List of additional include paths to use when parsing the header file.
     - anon_filename_decl_prefix_allowlist (list[str]): List of prefixes to allow for anonymous filename declarations.
-    -
+    - predefined_macros (list[str]): List of macros defined prior to parsing the header and prefixing shim functions.
     - additional_imports (list[str]): The list of additional imports to add to binding.
     - shim_include_override (str, optional): The command to override the include line of the shim functions.
     - require_pynvjitlink (bool, optional): If true, detect if pynvjitlink is installed, raise an error if not.

--- a/numbast/src/numbast/tools/static_binding_generator.py
+++ b/numbast/src/numbast/tools/static_binding_generator.py
@@ -58,6 +58,8 @@ class YamlConfig:
     shim_include_override : str:
         Override the include line of the shim function to specified string.
         If not specified, default to `#include <path_to_entry_point>`.
+
+    TODO: Migrate the docstring from `_static_binding_generator` to here.
     """
 
     entry_point: str
@@ -72,6 +74,7 @@ class YamlConfig:
     shim_include_override: str
     require_pynvjitlink: bool
     predefined_macros: list[str]
+    output_name: str
 
     def __init__(self, cfg_path):
         with open(cfg_path) as f:
@@ -111,6 +114,8 @@ class YamlConfig:
                 self.exclude_structs = []
             if self.clang_includes_paths is None:
                 self.clang_includes_paths = []
+
+            self.output_name = config.get("Output Name", None)
 
         self._verify_exists()
 
@@ -292,6 +297,7 @@ def _static_binding_generator(
     exclude_structs: list[str],
     clang_include_paths: list[str],
     anon_filename_decl_prefix_allowlist: list[str],
+    output_name: str = None,
     predefined_macros: list[str] = [],
     additional_imports: list[str] = [],
     shim_include_override: str | None = None,
@@ -314,6 +320,7 @@ def _static_binding_generator(
     - exclude_structs (list[str]): List of struct names to exclude from the bindings.
     - clang_include_paths (list[str]): List of additional include paths to use when parsing the header file.
     - anon_filename_decl_prefix_allowlist (list[str]): List of prefixes to allow for anonymous filename declarations.
+    - output_name (str): The name of the output binding file, default None. When set to None, use the same name as input file (renamed with .py extension)
     - predefined_macros (list[str]): List of macros defined prior to parsing the header and prefixing shim functions.
     - additional_imports (list[str]): The list of additional imports to add to binding.
     - shim_include_override (str, optional): The command to override the include line of the shim functions.
@@ -382,7 +389,10 @@ def _static_binding_generator(
     imports_str = get_rendered_imports(additional_imports=additional_imports)
 
     # Example: Save the processed output to the output directory
-    output_file = os.path.join(output_dir, f"{basename}.py")
+    if output_name is None:
+        output_file = os.path.join(output_dir, f"{basename}.py")
+    else:
+        output_file = os.path.join(output_dir, output_name)
 
     # Full command line that generate the binding:
     cmd = " ".join(sys.argv)
@@ -516,6 +526,7 @@ def static_binding_generator(
             cfg.exclude_structs,
             cfg.clang_includes_paths,
             cfg.macro_expanded_function_prefixes,
+            cfg.output_name,
             cfg.predefined_macros,
             cfg.additional_imports,
             cfg.shim_include_override,

--- a/numbast/src/numbast/tools/tests/config/output_name.yml.j2
+++ b/numbast/src/numbast/tools/tests/config/output_name.yml.j2
@@ -1,0 +1,11 @@
+Name: Test Data
+Version: 0.0.1
+Entry Point: {{ data }}
+File List:
+    - {{ data }}
+Exclude: {}
+Types:
+    Foo: Type
+Data Models:
+    Foo: StructModel
+Output Name: {{ output_name }}

--- a/numbast/src/numbast/tools/tests/conftest.py
+++ b/numbast/src/numbast/tools/tests/conftest.py
@@ -36,6 +36,7 @@ def run_in_isolated_folder(tmpdir):
         cfg_template,
         header,
         params,
+        output_name=None,
         ruff_format=False,
         load_symbols=False,
         show_binding=False,
@@ -52,6 +53,8 @@ def run_in_isolated_folder(tmpdir):
         shutil.copy(src_data, target_data)
 
         params["data"] = target_data
+        if output_name is not None:
+            params["output_name"] = output_name
 
         env = Environment(loader=FileSystemLoader(here))
         template = env.get_template(os.path.join("config/", cfg_template))
@@ -75,8 +78,9 @@ def run_in_isolated_folder(tmpdir):
 
         assert result.exit_code == 0
 
-        binding_name = header.split(".")[0] + ".py"
-        binding_path = os.path.join(output_folder, binding_name)
+        if output_name is None:
+            output_name = header.split(".")[0] + ".py"
+        binding_path = os.path.join(output_folder, output_name)
 
         with open(binding_path) as f:
             binding = f.read()

--- a/numbast/src/numbast/tools/tests/test_output_name.py
+++ b/numbast/src/numbast/tools/tests/test_output_name.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import subprocess
+import sys
+
+
+def test_output_name_override(run_in_isolated_folder):
+    """Tests:
+    1. Name of output binding can be overridden via `Output Name` entry.
+    """
+
+    module_name = "bindings"
+    output_name = f"{module_name}.py"
+    res = run_in_isolated_folder(
+        "output_name.yml.j2",
+        "data.cuh",
+        {},
+        output_name=output_name,
+        ruff_format=False,
+    )
+
+    run_result = res["result"]
+    output_folder = res["output_folder"]
+    binding_path = res["binding_path"]
+
+    assert run_result.exit_code == 0
+    assert output_name in binding_path
+
+    test_kernel_src = f"""
+from numba import cuda
+from {module_name} import Foo, add
+@cuda.jit
+def kernel():
+    foo = Foo()
+    one = add(foo.x, 1)
+
+kernel[1, 1]()
+"""
+
+    test_kernel = os.path.join(output_folder, "test.py")
+    with open(test_kernel, "w") as f:
+        f.write(test_kernel_src)
+
+    res = subprocess.run(
+        [sys.executable, test_kernel],
+        cwd=output_folder,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+    assert res.returncode == 0, res.stdout.decode("utf-8")


### PR DESCRIPTION
This PR adds `Output Name` Field to configuration, that allows custom name for the generated binding file.
