### PR TITLE
Add config for functions that requires cooperative launch

### DIFF
--- a/numbast/src/numbast/tools/tests/config/cooperative_launch.yml.j2
+++ b/numbast/src/numbast/tools/tests/config/cooperative_launch.yml.j2
@@ -1,0 +1,12 @@
+Name: Cooperative Launch
+Version: 0.0.1
+Entry Point: {{ data }}
+File List:
+    - {{ data }}
+Exclude: {}
+Types:
+    Foo: Type
+Data Models:
+    Foo: StructModel
+Cooperative Launch Required APIs:
+    - cta_barrier

--- a/numbast/src/numbast/tools/tests/conftest.py
+++ b/numbast/src/numbast/tools/tests/conftest.py
@@ -76,7 +76,7 @@ def run_in_isolated_folder(tmpdir):
             ],
         )
 
-        assert result.exit_code == 0
+        assert result.exit_code == 0, result.stdout
 
         if output_name is None:
             output_name = header.split(".")[0] + ".py"

--- a/numbast/src/numbast/tools/tests/test_use_cooperative.py
+++ b/numbast/src/numbast/tools/tests/test_use_cooperative.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import subprocess
+import sys
+
+
+def test_use_cooperative(run_in_isolated_folder):
+    """Test that only a limited set of symbols are exposed via __all__ imports."""
+    res = run_in_isolated_folder(
+        "cooperative_launch.yml.j2",
+        "use_cooperative.cuh",
+        {},
+        load_symbols=True,
+        ruff_format=False,
+    )
+
+    run_result = res["result"]
+    output_folder = res["output_folder"]
+
+    assert run_result.exit_code == 0
+
+    test_kernel_src = """
+from numba import cuda
+from use_cooperative import cta_barrier
+@cuda.jit
+def kernel():
+    cta_barrier()
+
+kernel[1, 1]()
+"""
+
+    test_kernel = os.path.join(output_folder, "test.py")
+    with open(test_kernel, "w") as f:
+        f.write(test_kernel_src)
+
+    res = subprocess.run(
+        [sys.executable, test_kernel],
+        cwd=output_folder,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+    assert res.returncode == 0, res.stdout.decode("utf-8")

--- a/numbast/src/numbast/tools/tests/test_use_cooperative.py
+++ b/numbast/src/numbast/tools/tests/test_use_cooperative.py
@@ -29,6 +29,7 @@ def kernel():
     cta_barrier()
 
 kernel[1, 1]()
+assert kernel.overloads[()].cooperative, f"{{kernel.overloads[()].cooperative=}}"
 """
 
     test_kernel = os.path.join(output_folder, "test.py")

--- a/numbast/src/numbast/tools/tests/use_cooperative.cuh
+++ b/numbast/src/numbast/tools/tests/use_cooperative.cuh
@@ -1,0 +1,21 @@
+#include <cooperative_groups.h>
+#include <cuda/barrier>
+
+namespace cg = cooperative_groups;
+
+__device__ void _wait_on_tile(cuda::barrier<cuda::thread_scope_block> &tile) {
+  auto token = tile.arrive();
+  tile.wait(std::move(token));
+}
+
+extern "C" __device__ int cta_barrier() {
+  auto cta = cg::this_thread_block();
+  cg::thread_block_tile<32> tile = cg::tiled_partition<32>(cta);
+  __shared__ cuda::barrier<cuda::thread_scope_block> barrier;
+  if (threadIdx.x == 0) {
+    init(&barrier, blockDim.x);
+  }
+
+  _wait_on_tile(barrier);
+  return 0;
+}

--- a/numbast/src/numbast/tools/tests/use_cooperative.cuh
+++ b/numbast/src/numbast/tools/tests/use_cooperative.cuh
@@ -1,14 +1,20 @@
+// clang-format off
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// clang-format on
+
 #include <cooperative_groups.h>
 #include <cuda/barrier>
 
 namespace cg = cooperative_groups;
 
-__device__ void _wait_on_tile(cuda::barrier<cuda::thread_scope_block> &tile) {
+__device__ __inline__ void
+_wait_on_tile(cuda::barrier<cuda::thread_scope_block> &tile) {
   auto token = tile.arrive();
   tile.wait(std::move(token));
 }
 
-extern "C" __device__ int cta_barrier() {
+extern "C" __device__ __inline__ int cta_barrier() {
   auto cta = cg::this_thread_block();
   cg::thread_block_tile<32> tile = cg::tiled_partition<32>(cta);
   __shared__ cuda::barrier<cuda::thread_scope_block> barrier;


### PR DESCRIPTION
This PR adds config: `Cooperative Launch Required APIs`, a list of strings that specify the names of the function that requires cooperative launch.