### PR TITLE
Alter cooperative launch list to regex list

### DIFF
--- a/numbast/src/numbast/static/function.py
+++ b/numbast/src/numbast/static/function.py
@@ -34,6 +34,8 @@ function_apis_registry: set[str] = set()
 def _matches_any_regex_pattern(name: str, patterns: list[str]) -> bool:
     """Check if a function name matches any of the provided regex patterns.
 
+    NOTE: This function assumes all input patterns are valid regex patterns.
+
     Parameters
     ----------
     name : str
@@ -47,13 +49,8 @@ def _matches_any_regex_pattern(name: str, patterns: list[str]) -> bool:
         True if the name matches any pattern, False otherwise
     """
     for pattern in patterns:
-        try:
-            if re.search(pattern, name):
-                return True
-        except re.error:
-            # If regex is invalid, log warning and skip
-            warn(f"Invalid regex pattern: {pattern}")
-            continue
+        if re.search(pattern, name):
+            return True
     return False
 
 

--- a/numbast/src/numbast/tools/static_binding_generator.py
+++ b/numbast/src/numbast/tools/static_binding_generator.py
@@ -35,6 +35,7 @@ from numbast.static.function import (
 )
 from numbast.static.enum import StaticEnumsRenderer
 from numbast.static.typedef import render_aliases
+from numbast.tools.yaml_tags import string_constructor
 
 config.CUDA_USE_NVIDIA_BINDING = True
 
@@ -42,6 +43,9 @@ VERBOSE = False
 
 CUDA_INCLUDE_PATH = config.CUDA_INCLUDE_PATH
 MACHINE_COMPUTE_CAPABILITY = cuda.get_current_device().compute_capability
+
+# Register custom YAML constructor for !join tag
+yaml.add_constructor("!numbast_join", string_constructor)
 
 
 class YamlConfig:

--- a/numbast/src/numbast/tools/static_binding_generator.py
+++ b/numbast/src/numbast/tools/static_binding_generator.py
@@ -79,9 +79,10 @@ class YamlConfig:
     output_name : str
         The name of the output binding file, default None. When set to None, use
         the same name as input file (renamed with .py extension).
-    cooperative_launch_required_apis : list[str]
-        The list of functions, when used in kernel, should cause the kernel to be
-        launched with cooperative launch.
+    cooperative_launch_required_functions_regex : list[str]
+        The list of regular expressions. When any function name matches any of these
+        regex patterns, the function should cause the kernel to be launched with
+        cooperative launch.
     """
 
     entry_point: str
@@ -97,7 +98,7 @@ class YamlConfig:
     require_pynvjitlink: bool
     predefined_macros: list[str]
     output_name: str
-    cooperative_launch_required_apis: list[str]
+    cooperative_launch_required_functions_regex: list[str]
 
     def __init__(self, cfg_path):
         with open(cfg_path) as f:
@@ -140,8 +141,8 @@ class YamlConfig:
 
             self.output_name = config.get("Output Name", None)
 
-            self.cooperative_launch_required_apis = config.get(
-                "Cooperative Launch Required APIs", []
+            self.cooperative_launch_required_functions_regex = config.get(
+                "Cooperative Launch Required Functions Regex", []
             )
 
         self._verify_exists()
@@ -162,7 +163,7 @@ class YamlConfig:
         require_pynvjitlink: bool = False,
         predefined_macros: list[str] = None,
         output_name: str = None,
-        cooperative_launch_required_apis: list[str] = None,
+        cooperative_launch_required_functions_regex: list[str] = None,
     ):
         """Create a YamlConfig instance from individual parameters instead of a config file."""
         instance = cls.__new__(cls)
@@ -181,8 +182,8 @@ class YamlConfig:
         instance.require_pynvjitlink = require_pynvjitlink
         instance.predefined_macros = predefined_macros or []
         instance.output_name = output_name
-        instance.cooperative_launch_required_apis = (
-            cooperative_launch_required_apis or []
+        instance.cooperative_launch_required_functions_regex = (
+            cooperative_launch_required_functions_regex or []
         )
         instance._verify_exists()
         return instance
@@ -431,7 +432,7 @@ def _static_binding_generator(
         functions,
         entry_point,
         config.exclude_functions,
-        config.cooperative_launch_required_apis,
+        config.cooperative_launch_required_functions_regex,
     )
 
     if config.require_pynvjitlink:

--- a/numbast/src/numbast/tools/static_binding_generator.py
+++ b/numbast/src/numbast/tools/static_binding_generator.py
@@ -9,6 +9,7 @@ import sys
 import subprocess
 import importlib
 import warnings
+import re
 
 import yaml
 
@@ -146,6 +147,7 @@ class YamlConfig:
             )
 
         self._verify_exists()
+        self._verify_regex_patterns()
 
     @classmethod
     def from_params(
@@ -186,6 +188,7 @@ class YamlConfig:
             cooperative_launch_required_functions_regex or []
         )
         instance._verify_exists()
+        instance._verify_regex_patterns()
         return instance
 
     def _verify_exists(self):
@@ -199,6 +202,13 @@ class YamlConfig:
         for f in self.clang_includes_paths:
             if not os.path.exists(f):
                 raise ValueError(f"File in include list does not exist: {f}")
+
+    def _verify_regex_patterns(self):
+        for pattern in self.cooperative_launch_required_functions_regex:
+            try:
+                re.compile(pattern)
+            except re.error:
+                raise ValueError(f"Invalid regex pattern: {pattern}")
 
 
 def _str_value_to_numba_type(d: dict[str, str]) -> dict[str, type]:

--- a/numbast/src/numbast/tools/tests/config/cooperative_launch.yml.j2
+++ b/numbast/src/numbast/tools/tests/config/cooperative_launch.yml.j2
@@ -8,5 +8,5 @@ Types:
     Foo: Type
 Data Models:
     Foo: StructModel
-Cooperative Launch Required APIs:
-    - cta_barrier
+Cooperative Launch Required Functions Regex:
+    - "cta_barrier"

--- a/numbast/src/numbast/tools/tests/config/cooperative_launch_invalid_regex.yml.j2
+++ b/numbast/src/numbast/tools/tests/config/cooperative_launch_invalid_regex.yml.j2
@@ -1,0 +1,12 @@
+Name: Cooperative Launch Invalid Regex
+Version: 0.0.1
+Entry Point: {{ data }}
+File List:
+    - {{ data }}
+Exclude: {}
+Types:
+    Foo: Type
+Data Models:
+    Foo: StructModel
+Cooperative Launch Required Functions Regex:
+    - "[invalid_regex"

--- a/numbast/src/numbast/tools/tests/config/cooperative_launch_invalid_regex.yml.j2
+++ b/numbast/src/numbast/tools/tests/config/cooperative_launch_invalid_regex.yml.j2
@@ -10,3 +10,4 @@ Data Models:
     Foo: StructModel
 Cooperative Launch Required Functions Regex:
     - "[invalid_regex"
+    - "invalid_regex2]"

--- a/numbast/src/numbast/tools/tests/config/cooperative_launch_regex.yml.j2
+++ b/numbast/src/numbast/tools/tests/config/cooperative_launch_regex.yml.j2
@@ -1,0 +1,13 @@
+Name: Cooperative Launch Regex
+Version: 0.0.1
+Entry Point: {{ data }}
+File List:
+    - {{ data }}
+Exclude: {}
+Types:
+    Foo: Type
+Data Models:
+    Foo: StructModel
+Cooperative Launch Required Functions Regex:
+    - ".*_barrier.*"
+    - ".*_sync.*"

--- a/numbast/src/numbast/tools/tests/conftest.py
+++ b/numbast/src/numbast/tools/tests/conftest.py
@@ -3,6 +3,7 @@
 
 import os
 import shutil
+import warnings
 
 import pytest
 
@@ -63,18 +64,20 @@ def run_in_isolated_folder(tmpdir):
         with open(config_path, "w") as f:
             f.write(config)
 
-        runner = CliRunner()
-        result = runner.invoke(
-            static_binding_generator,
-            [
-                "--cfg-path",
-                config_path,
-                "--output-dir",
-                output_folder,
-                "-fmt",
-                "true" if ruff_format else "false",
-            ],
-        )
+        runner = CliRunner(catch_exceptions=False)
+
+        with warnings.catch_warnings(record=True) as w:
+            result = runner.invoke(
+                static_binding_generator,
+                [
+                    "--cfg-path",
+                    config_path,
+                    "--output-dir",
+                    output_folder,
+                    "-fmt",
+                    "true" if ruff_format else "false",
+                ],
+            )
 
         assert result.exit_code == 0, result.stdout
 
@@ -98,6 +101,7 @@ def run_in_isolated_folder(tmpdir):
             "binding_path": binding_path,
             "binding": binding,
             "symbols": symbols,
+            "warnings": w,
         }
 
     return _run

--- a/numbast/src/numbast/tools/tests/test_use_cooperative.py
+++ b/numbast/src/numbast/tools/tests/test_use_cooperative.py
@@ -44,3 +44,131 @@ assert kernel.overloads[()].cooperative, f"{{kernel.overloads[()].cooperative=}}
     )
 
     assert res.returncode == 0, res.stdout.decode("utf-8")
+
+
+def test_use_cooperative_regex_patterns(run_in_isolated_folder):
+    """Test that regex patterns correctly match function names for cooperative launch."""
+    res = run_in_isolated_folder(
+        "cooperative_launch_regex.yml.j2",
+        "use_cooperative.cuh",
+        {},
+        load_symbols=True,
+        ruff_format=False,
+    )
+
+    run_result = res["result"]
+    output_folder = res["output_folder"]
+
+    assert run_result.exit_code == 0
+
+    # Test functions that should match .*_barrier.* pattern
+    test_barrier_kernel_src = """
+from numba import cuda
+from use_cooperative import global_barrier_sync, thread_barrier_wait
+
+@cuda.jit
+def barrier_kernel():
+    global_barrier_sync()
+
+@cuda.jit
+def thread_barrier_kernel():
+    thread_barrier_wait()
+
+barrier_kernel[1, 1]()
+thread_barrier_kernel[1, 1]()
+
+assert barrier_kernel.overloads[()].cooperative, f"global_barrier_sync should be cooperative: {{barrier_kernel.overloads[()].cooperative=}}"
+assert thread_barrier_kernel.overloads[()].cooperative, f"thread_barrier_wait should be cooperative: {{thread_barrier_kernel.overloads[()].cooperative=}}"
+"""
+
+    # Test functions that should match .*_sync.* pattern
+    test_sync_kernel_src = """
+from numba import cuda
+from use_cooperative import grid_sync_all, block_sync_threads
+
+@cuda.jit
+def grid_sync_kernel():
+    grid_sync_all()
+
+@cuda.jit
+def block_sync_kernel():
+    block_sync_threads()
+
+grid_sync_kernel[1, 1]()
+block_sync_kernel[1, 1]()
+
+assert grid_sync_kernel.overloads[()].cooperative, f"grid_sync_all should be cooperative: {{grid_sync_kernel.overloads[()].cooperative=}}"
+assert block_sync_kernel.overloads[()].cooperative, f"block_sync_threads should be cooperative: {{block_sync_kernel.overloads[()].cooperative=}}"
+"""
+
+    # Test barrier functions
+    test_barrier_kernel = os.path.join(output_folder, "test_barrier.py")
+    with open(test_barrier_kernel, "w") as f:
+        f.write(test_barrier_kernel_src)
+
+    res = subprocess.run(
+        [sys.executable, test_barrier_kernel],
+        cwd=output_folder,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+    assert res.returncode == 0, res.stdout.decode("utf-8")
+
+    # Test sync functions
+    test_sync_kernel = os.path.join(output_folder, "test_sync.py")
+    with open(test_sync_kernel, "w") as f:
+        f.write(test_sync_kernel_src)
+
+    res = subprocess.run(
+        [sys.executable, test_sync_kernel],
+        cwd=output_folder,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+    assert res.returncode == 0, res.stdout.decode("utf-8")
+
+
+def test_use_cooperative_non_matching_functions(run_in_isolated_folder):
+    """Test that functions not matching regex patterns are not marked as cooperative."""
+    res = run_in_isolated_folder(
+        "cooperative_launch_regex.yml.j2",
+        "use_cooperative.cuh",
+        {},
+        load_symbols=True,
+        ruff_format=False,
+    )
+
+    run_result = res["result"]
+    output_folder = res["output_folder"]
+
+    assert run_result.exit_code == 0
+
+    # Test functions that should NOT match any patterns
+    test_non_coop_kernel_src = """
+from numba import cuda
+from use_cooperative import regular_function
+
+@cuda.jit
+def regular_kernel():
+    regular_function()
+
+regular_kernel[1, 1]()
+
+# These functions should NOT be marked as cooperative
+assert not regular_kernel.overloads[()].cooperative, f"regular_function should not be cooperative: {{regular_kernel.overloads[()].cooperative=}}"
+"""
+
+    test_non_coop_kernel = os.path.join(output_folder, "test_non_coop.py")
+    with open(test_non_coop_kernel, "w") as f:
+        f.write(test_non_coop_kernel_src)
+
+    res = subprocess.run(
+        [sys.executable, test_non_coop_kernel],
+        cwd=output_folder,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+    assert res.returncode == 0, res.stdout.decode("utf-8")

--- a/numbast/src/numbast/tools/tests/test_use_cooperative.py
+++ b/numbast/src/numbast/tools/tests/test_use_cooperative.py
@@ -5,6 +5,8 @@ import os
 import subprocess
 import sys
 
+import pytest
+
 
 def test_use_cooperative(run_in_isolated_folder):
     """Test that only a limited set of symbols are exposed via __all__ imports."""
@@ -172,3 +174,16 @@ assert not regular_kernel.overloads[()].cooperative, f"regular_function should n
     )
 
     assert res.returncode == 0, res.stdout.decode("utf-8")
+
+
+def test_use_cooperative_invalid_regex(run_in_isolated_folder):
+    """Test that functions not matching regex patterns are not marked as cooperative."""
+
+    with pytest.raises(ValueError, match="Invalid regex pattern"):
+        run_in_isolated_folder(
+            "cooperative_launch_invalid_regex.yml.j2",
+            "use_cooperative.cuh",
+            {},
+            load_symbols=True,
+            ruff_format=False,
+        )

--- a/numbast/src/numbast/tools/tests/use_cooperative.cuh
+++ b/numbast/src/numbast/tools/tests/use_cooperative.cuh
@@ -25,3 +25,55 @@ extern "C" __device__ __inline__ int cta_barrier() {
   _wait_on_tile(barrier);
   return 0;
 }
+
+// Functions for regex testing - these should match pattern ".*_barrier.*"
+extern "C" __device__ __inline__ int global_barrier_sync() {
+  auto cta = cg::this_thread_block();
+  cg::thread_block_tile<32> tile = cg::tiled_partition<32>(cta);
+  __shared__ cuda::barrier<cuda::thread_scope_block> barrier;
+  if (threadIdx.x == 0) {
+    init(&barrier, blockDim.x);
+  }
+  _wait_on_tile(barrier);
+  return 0;
+}
+
+extern "C" __device__ __inline__ int thread_barrier_wait() {
+  auto cta = cg::this_thread_block();
+  cg::thread_block_tile<32> tile = cg::tiled_partition<32>(cta);
+  __shared__ cuda::barrier<cuda::thread_scope_block> barrier;
+  if (threadIdx.x == 0) {
+    init(&barrier, blockDim.x);
+  }
+  _wait_on_tile(barrier);
+  return 0;
+}
+
+// Functions for regex testing - these should match pattern ".*_sync.*"
+extern "C" __device__ __inline__ int grid_sync_all() {
+  auto cta = cg::this_thread_block();
+  cg::thread_block_tile<32> tile = cg::tiled_partition<32>(cta);
+  __shared__ cuda::barrier<cuda::thread_scope_block> barrier;
+  if (threadIdx.x == 0) {
+    init(&barrier, blockDim.x);
+  }
+  _wait_on_tile(barrier);
+  return 0;
+}
+
+extern "C" __device__ __inline__ int block_sync_threads() {
+  auto cta = cg::this_thread_block();
+  cg::thread_block_tile<32> tile = cg::tiled_partition<32>(cta);
+  __shared__ cuda::barrier<cuda::thread_scope_block> barrier;
+  if (threadIdx.x == 0) {
+    init(&barrier, blockDim.x);
+  }
+  _wait_on_tile(barrier);
+  return 0;
+}
+
+// Functions that should NOT match any patterns - these should not be
+// cooperative
+extern "C" __device__ __inline__ int regular_function() {
+  return threadIdx.x + blockIdx.x;
+}

--- a/numbast/src/numbast/tools/yaml_tags.py
+++ b/numbast/src/numbast/tools/yaml_tags.py
@@ -1,0 +1,3 @@
+def string_constructor(loader, node):
+    seq = loader.construct_sequence(node)
+    return "".join(seq)


### PR DESCRIPTION
In #133 we introduced a list of function names that specifies bindings that requires cooperative launch. In certain uses cases this list can grow too large (parameterized function names such as `[TYPENAME]_sync` where TYPENAME can grow beyond 20 types). A regex is more succinct in representing these requirements.
