### PR TITLE
Capture Namespaces for all Declarations

### DIFF
--- a/ast_canopy/cpp/CMakeLists.txt
+++ b/ast_canopy/cpp/CMakeLists.txt
@@ -15,6 +15,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 # Define the sources to compile for astcanopy here.
 add_library(astcanopy SHARED
             src/ast_canopy.cpp
+            src/declaration.cpp
             src/enum.cpp
             src/class_template.cpp
             src/field.cpp
@@ -27,6 +28,7 @@ add_library(astcanopy SHARED
             src/template_param.cpp
             src/type.cpp
             src/typedef.cpp
+            src/utils.cpp
             src/constexpr_vardecl.cpp
             src/detail/matchers/function_matcher.cpp
             src/detail/matchers/record_matcher.cpp
@@ -43,7 +45,8 @@ target_sources(astcanopy
   FILE_SET public_headers
   TYPE HEADERS
   BASE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/include
-  FILES include/ast_canopy/ast_canopy.hpp)
+  FILES include/ast_canopy/ast_canopy.hpp
+            include/ast_canopy/utils.hpp)
 
 # astcanopy shared lib target
 find_package(Clang REQUIRED)

--- a/ast_canopy/cpp/include/ast_canopy/ast_canopy.hpp
+++ b/ast_canopy/cpp/include/ast_canopy/ast_canopy.hpp
@@ -41,6 +41,9 @@ struct Declaration {
   // For example, for a declaration in "outer::middle::inner", the vector
   // would contain ["inner", "middle", "outer"]
   std::vector<std::string> namespace_stack;
+
+  Declaration() = default;
+  explicit Declaration(const clang::Decl *decl);
   virtual ~Declaration() = default;
 };
 

--- a/ast_canopy/cpp/include/ast_canopy/ast_canopy.hpp
+++ b/ast_canopy/cpp/include/ast_canopy/ast_canopy.hpp
@@ -46,9 +46,7 @@ struct Declaration {
 
 struct Enum : public Declaration {
   Enum(const std::string &name, const std::vector<std::string> &enumerators,
-       const std::vector<std::string> &enumerator_values)
-      : name(name), enumerators(enumerators),
-        enumerator_values(enumerator_values) {}
+       const std::vector<std::string> &enumerator_values);
   Enum(const clang::EnumDecl *);
 
   std::string name;
@@ -65,8 +63,8 @@ struct Type {
   std::string name;
   std::string unqualified_non_ref_type_name;
 
-  bool is_right_reference() const { return _is_right_reference; }
-  bool is_left_reference() const { return _is_left_reference; }
+  bool is_right_reference() const;
+  bool is_left_reference() const;
 
 private:
   bool _is_right_reference;
@@ -84,8 +82,7 @@ struct ConstExprVar {
 
 struct Field {
   Field(const clang::FieldDecl *FD, const clang::AccessSpecifier &AS);
-  Field(const std::string &name, const Type &type, const access_kind &access)
-      : name(name), type(type), access(access) {};
+  Field(const std::string &name, const Type &type, const access_kind &access);
 
   std::string name;
   Type type;
@@ -93,7 +90,7 @@ struct Field {
 };
 
 struct ParamVar {
-  ParamVar(std::string name, Type type) : name(std::move(name)), type(type) {}
+  ParamVar(std::string name, Type type);
   ParamVar(const clang::ParmVarDecl *PVD);
 
   std::string name;
@@ -102,9 +99,7 @@ struct ParamVar {
 
 struct Template {
   Template(const std::vector<TemplateParam> &template_parameters,
-           const std::size_t &num_min_required_args)
-      : template_parameters(template_parameters),
-        num_min_required_args(num_min_required_args) {}
+           const std::size_t &num_min_required_args);
   Template(const clang::TemplateParameterList *);
 
   std::vector<TemplateParam> template_parameters;
@@ -127,9 +122,7 @@ struct TemplateParam {
 struct Function : public Declaration {
   Function(const std::string &name, const Type &return_type,
            const std::vector<ParamVar> &params,
-           const execution_space &exec_space)
-      : name(name), return_type(return_type), params(params),
-        exec_space(exec_space) {}
+           const execution_space &exec_space);
   Function(const clang::FunctionDecl *);
 
   std::string name;
@@ -142,9 +135,7 @@ struct Function : public Declaration {
 struct FunctionTemplate : public Template, public Declaration {
   FunctionTemplate(const std::vector<TemplateParam> &template_parameters,
                    const std::size_t &num_min_required_args,
-                   const Function &function)
-      : Template(std::move(template_parameters), num_min_required_args),
-        function(std::move(function)) {}
+                   const Function &function);
   FunctionTemplate(const clang::FunctionTemplateDecl *);
   Function function;
 };
@@ -152,8 +143,7 @@ struct FunctionTemplate : public Template, public Declaration {
 struct Method : public Function {
   Method(const std::string &name, const Type &return_type,
          const std::vector<ParamVar> &params, const execution_space &exec_space,
-         const method_kind &kind)
-      : Function(name, return_type, params, exec_space), kind(kind) {}
+         const method_kind &kind);
   Method(const clang::CXXMethodDecl *);
   method_kind kind;
 
@@ -175,11 +165,7 @@ struct Record : public Declaration {
          const std::vector<Record> &nested_records,
          const std::vector<ClassTemplate> &nested_class_templates,
          const std::size_t &sizeof_, const std::size_t &alignof_,
-         const std::string &source_range)
-      : name(name), fields(fields), methods(methods),
-        templated_methods(templated_methods), nested_records(nested_records),
-        nested_class_templates(nested_class_templates), sizeof_(sizeof_),
-        alignof_(alignof_), source_range(source_range) {}
+         const std::string &source_range);
   Record(const clang::CXXRecordDecl *, RecordAncestor);
   Record(const clang::CXXRecordDecl *, RecordAncestor,
          std::string); // overrides name from RD
@@ -203,8 +189,7 @@ struct ClassTemplate : public Template, public Declaration {
 };
 
 struct Typedef : public Declaration {
-  Typedef(const std::string &name, const std::string &underlying_name)
-      : name(name), underlying_name(underlying_name) {}
+  Typedef(const std::string &name, const std::string &underlying_name);
   Typedef(const clang::TypedefDecl *,
           std::unordered_map<int64_t, std::string> *);
 

--- a/ast_canopy/cpp/include/ast_canopy/utils.hpp
+++ b/ast_canopy/cpp/include/ast_canopy/utils.hpp
@@ -1,0 +1,22 @@
+// clang-format off
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// clang-format on
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace clang {
+class Decl;
+}
+
+namespace ast_canopy {
+
+// Extracts namespace names from a Clang declaration in bottom-up order
+// (deepest to top-level). For example, for a declaration in
+// "outer::middle::inner", the vector would contain ["inner", "middle", "outer"]
+std::vector<std::string> extract_namespace_stack(const clang::Decl *decl);
+
+} // namespace ast_canopy

--- a/ast_canopy/cpp/src/class_template.cpp
+++ b/ast_canopy/cpp/src/class_template.cpp
@@ -12,7 +12,9 @@
 #include <iostream>
 
 namespace ast_canopy {
+
 ClassTemplate::ClassTemplate(const clang::ClassTemplateDecl *CTD)
-    : Template(CTD->getTemplateParameters()),
+    : Template(CTD->getTemplateParameters()), Declaration(CTD),
       record(CTD->getTemplatedDecl(), RecordAncestor::ANCESTOR_IS_TEMPLATE) {}
+
 } // namespace ast_canopy

--- a/ast_canopy/cpp/src/class_template.cpp
+++ b/ast_canopy/cpp/src/class_template.cpp
@@ -13,6 +13,13 @@
 
 namespace ast_canopy {
 
+ClassTemplate::ClassTemplate(
+    const std::vector<TemplateParam> &template_parameters,
+    const std::size_t &num_min_required_args, const Record &record,
+    const std::vector<std::string> &namespace_stack)
+    : Template(template_parameters, num_min_required_args),
+      Declaration(namespace_stack), record(record) {}
+
 ClassTemplate::ClassTemplate(const clang::ClassTemplateDecl *CTD)
     : Template(CTD->getTemplateParameters()), Declaration(CTD),
       record(CTD->getTemplatedDecl(), RecordAncestor::ANCESTOR_IS_TEMPLATE) {}

--- a/ast_canopy/cpp/src/declaration.cpp
+++ b/ast_canopy/cpp/src/declaration.cpp
@@ -8,6 +8,9 @@
 
 namespace ast_canopy {
 
+Declaration::Declaration(const std::vector<std::string> &ns_stack)
+    : namespace_stack(ns_stack) {}
+
 Declaration::Declaration(const clang::Decl *decl)
     : namespace_stack(extract_namespace_stack(decl)) {}
 

--- a/ast_canopy/cpp/src/declaration.cpp
+++ b/ast_canopy/cpp/src/declaration.cpp
@@ -1,0 +1,14 @@
+// clang-format off
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// clang-format on
+
+#include <ast_canopy/ast_canopy.hpp>
+#include <ast_canopy/utils.hpp>
+
+namespace ast_canopy {
+
+Declaration::Declaration(const clang::Decl *decl)
+    : namespace_stack(extract_namespace_stack(decl)) {}
+
+} // namespace ast_canopy

--- a/ast_canopy/cpp/src/detail/matchers/record_matcher.cpp
+++ b/ast_canopy/cpp/src/detail/matchers/record_matcher.cpp
@@ -5,9 +5,7 @@
 
 #include "matchers.hpp"
 
-#ifndef NDEBUG
 #include <iostream>
-#endif
 
 namespace ast_canopy {
 
@@ -27,7 +25,7 @@ void RecordCallback::run(const MatchFinder::MatchResult &Result) {
                   payload->files_to_retain->end(),
                   [&file_name](const std::string &file_to_retain) {
                     return file_name == file_to_retain;
-                  }))
+                  })) {
 
     if (RD->isThisDeclarationADefinition() && RD->isCompleteDefinition()) {
       // This is a complete definition, not a forward declaration.
@@ -52,6 +50,7 @@ void RecordCallback::run(const MatchFinder::MatchResult &Result) {
 
       auto &record_id_map = *payload->record_id_to_name;
       record_id_map[id] = rename_for_unamed;
+
       payload->decls->records.push_back(Record(
           RD, RecordAncestor::ANCESTOR_IS_NOT_TEMPLATE, rename_for_unamed));
 
@@ -61,6 +60,7 @@ void RecordCallback::run(const MatchFinder::MatchResult &Result) {
       std::cout << source_range << std::endl;
 #endif
     }
+  }
 }
 
 } // namespace detail

--- a/ast_canopy/cpp/src/enum.cpp
+++ b/ast_canopy/cpp/src/enum.cpp
@@ -12,7 +12,8 @@ Enum::Enum(const std::string &name, const std::vector<std::string> &enumerators,
     : name(name), enumerators(enumerators),
       enumerator_values(enumerator_values) {}
 
-Enum::Enum(const clang::EnumDecl *ED) : name(ED->getNameAsString()) {
+Enum::Enum(const clang::EnumDecl *ED)
+    : Declaration(ED), name(ED->getNameAsString()) {
   for (const auto *enumerator : ED->enumerators()) {
     enumerators.push_back(enumerator->getNameAsString());
 

--- a/ast_canopy/cpp/src/enum.cpp
+++ b/ast_canopy/cpp/src/enum.cpp
@@ -7,6 +7,11 @@
 
 namespace ast_canopy {
 
+Enum::Enum(const std::string &name, const std::vector<std::string> &enumerators,
+           const std::vector<std::string> &enumerator_values)
+    : name(name), enumerators(enumerators),
+      enumerator_values(enumerator_values) {}
+
 Enum::Enum(const clang::EnumDecl *ED) : name(ED->getNameAsString()) {
   for (const auto *enumerator : ED->enumerators()) {
     enumerators.push_back(enumerator->getNameAsString());

--- a/ast_canopy/cpp/src/enum.cpp
+++ b/ast_canopy/cpp/src/enum.cpp
@@ -8,8 +8,9 @@
 namespace ast_canopy {
 
 Enum::Enum(const std::string &name, const std::vector<std::string> &enumerators,
-           const std::vector<std::string> &enumerator_values)
-    : name(name), enumerators(enumerators),
+           const std::vector<std::string> &enumerator_values,
+           const std::vector<std::string> &namespace_stack)
+    : Declaration(namespace_stack), name(name), enumerators(enumerators),
       enumerator_values(enumerator_values) {}
 
 Enum::Enum(const clang::EnumDecl *ED)

--- a/ast_canopy/cpp/src/field.cpp
+++ b/ast_canopy/cpp/src/field.cpp
@@ -11,21 +11,30 @@
 
 namespace ast_canopy {
 
+Field::Field(const std::string &name, const Type &type,
+             const access_kind &access)
+    : name(name), type(type), access(access) {}
+
 Field::Field(const clang::FieldDecl *FD, const clang::AccessSpecifier &AS)
     : name(FD->getNameAsString()), type(FD->getType(), FD->getASTContext()) {
-  if (AS == clang::AccessSpecifier::AS_public)
+  switch (AS) {
+  case clang::AS_public:
     access = access_kind::public_;
-  else if (AS == clang::AccessSpecifier::AS_protected)
+    break;
+  case clang::AS_protected:
     access = access_kind::protected_;
-  else if (AS == clang::AccessSpecifier::AS_private)
+    break;
+  case clang::AS_private:
     access = access_kind::private_;
-  else {
+    break;
+  default:
     // Fields in a class / struct must have an access specifier. See logic
     // in record.cpp.
 #ifndef NDEBUG
     std::cout << "Access specifier is NONE for: " << name << std::endl;
 #endif
     access = access_kind::public_;
+    break;
   }
 }
 } // namespace ast_canopy

--- a/ast_canopy/cpp/src/function.cpp
+++ b/ast_canopy/cpp/src/function.cpp
@@ -8,8 +8,6 @@
 
 #include <ast_canopy/ast_canopy.hpp>
 
-#include <algorithm>
-
 namespace ast_canopy {
 
 execution_space get_execution_space(const clang::FunctionDecl *FD) {
@@ -27,19 +25,11 @@ execution_space get_execution_space(const clang::FunctionDecl *FD) {
   }
 }
 
-Function::Function(const std::string &name, const Type &return_type,
-                   const std::vector<ParamVar> &params,
-                   const execution_space &exec_space)
-    : name(name), return_type(return_type), params(params),
-      exec_space(exec_space) {}
-
 Function::Function(const clang::FunctionDecl *FD)
-    : name(FD->getNameAsString()),
+    : Declaration(FD), name(FD->getNameAsString()),
       return_type(FD->getReturnType(), FD->getASTContext()),
-      is_constexpr(FD->isConstexpr()) {
-  params.reserve(FD->getNumParams());
+      exec_space(get_execution_space(FD)), is_constexpr(FD->isConstexpr()) {
   std::transform(FD->param_begin(), FD->param_end(), std::back_inserter(params),
                  [](const clang::ParmVarDecl *PVD) { return ParamVar(PVD); });
-  exec_space = get_execution_space(FD);
 }
 } // namespace ast_canopy

--- a/ast_canopy/cpp/src/function.cpp
+++ b/ast_canopy/cpp/src/function.cpp
@@ -27,6 +27,12 @@ execution_space get_execution_space(const clang::FunctionDecl *FD) {
   }
 }
 
+Function::Function(const std::string &name, const Type &return_type,
+                   const std::vector<ParamVar> &params,
+                   const execution_space &exec_space)
+    : name(name), return_type(return_type), params(params),
+      exec_space(exec_space) {}
+
 Function::Function(const clang::FunctionDecl *FD)
     : name(FD->getNameAsString()),
       return_type(FD->getReturnType(), FD->getASTContext()),

--- a/ast_canopy/cpp/src/function.cpp
+++ b/ast_canopy/cpp/src/function.cpp
@@ -32,4 +32,11 @@ Function::Function(const clang::FunctionDecl *FD)
   std::transform(FD->param_begin(), FD->param_end(), std::back_inserter(params),
                  [](const clang::ParmVarDecl *PVD) { return ParamVar(PVD); });
 }
+
+Function::Function(const std::string &name, const Type &return_type,
+                   const std::vector<ParamVar> &params,
+                   const execution_space &exec_space,
+                   const std::vector<std::string> &namespace_stack)
+    : Declaration(namespace_stack), name(name), return_type(return_type),
+      params(params), exec_space(exec_space), is_constexpr(false) {}
 } // namespace ast_canopy

--- a/ast_canopy/cpp/src/function_template.cpp
+++ b/ast_canopy/cpp/src/function_template.cpp
@@ -15,6 +15,12 @@
 
 namespace ast_canopy {
 
+FunctionTemplate::FunctionTemplate(
+    const std::vector<TemplateParam> &template_parameters,
+    const std::size_t &num_min_required_args, const Function &function)
+    : Template(std::move(template_parameters), num_min_required_args),
+      function(std::move(function)) {}
+
 FunctionTemplate::FunctionTemplate(const clang::FunctionTemplateDecl *FTD)
     : Template(FTD->getTemplateParameters()),
       function(FTD->getTemplatedDecl()) {}

--- a/ast_canopy/cpp/src/function_template.cpp
+++ b/ast_canopy/cpp/src/function_template.cpp
@@ -22,6 +22,6 @@ FunctionTemplate::FunctionTemplate(
       function(std::move(function)) {}
 
 FunctionTemplate::FunctionTemplate(const clang::FunctionTemplateDecl *FTD)
-    : Template(FTD->getTemplateParameters()),
+    : Template(FTD->getTemplateParameters()), Declaration(FTD),
       function(FTD->getTemplatedDecl()) {}
 } // namespace ast_canopy

--- a/ast_canopy/cpp/src/function_template.cpp
+++ b/ast_canopy/cpp/src/function_template.cpp
@@ -17,9 +17,10 @@ namespace ast_canopy {
 
 FunctionTemplate::FunctionTemplate(
     const std::vector<TemplateParam> &template_parameters,
-    const std::size_t &num_min_required_args, const Function &function)
-    : Template(std::move(template_parameters), num_min_required_args),
-      function(std::move(function)) {}
+    const std::size_t &num_min_required_args, const Function &function,
+    const std::vector<std::string> &namespace_stack)
+    : Template(template_parameters, num_min_required_args),
+      Declaration(namespace_stack), function(function) {}
 
 FunctionTemplate::FunctionTemplate(const clang::FunctionTemplateDecl *FTD)
     : Template(FTD->getTemplateParameters()), Declaration(FTD),

--- a/ast_canopy/cpp/src/method.cpp
+++ b/ast_canopy/cpp/src/method.cpp
@@ -11,8 +11,10 @@ namespace ast_canopy {
 
 Method::Method(const std::string &name, const Type &return_type,
                const std::vector<ParamVar> &params,
-               const execution_space &exec_space, const method_kind &kind)
-    : Function(name, return_type, params, exec_space), kind(kind) {}
+               const execution_space &exec_space, const method_kind &kind,
+               const std::vector<std::string> &namespace_stack)
+    : Function(name, return_type, params, exec_space, namespace_stack),
+      kind(kind) {}
 
 Method::Method(const clang::CXXMethodDecl *MD) : Function(MD) {
   if (const clang::CXXConstructorDecl *CD =

--- a/ast_canopy/cpp/src/method.cpp
+++ b/ast_canopy/cpp/src/method.cpp
@@ -9,6 +9,11 @@
 
 namespace ast_canopy {
 
+Method::Method(const std::string &name, const Type &return_type,
+               const std::vector<ParamVar> &params,
+               const execution_space &exec_space, const method_kind &kind)
+    : Function(name, return_type, params, exec_space), kind(kind) {}
+
 Method::Method(const clang::CXXMethodDecl *MD) : Function(MD) {
   if (const clang::CXXConstructorDecl *CD =
           clang::dyn_cast<clang::CXXConstructorDecl>(MD)) {

--- a/ast_canopy/cpp/src/param_var.cpp
+++ b/ast_canopy/cpp/src/param_var.cpp
@@ -6,6 +6,9 @@
 #include <ast_canopy/ast_canopy.hpp>
 
 namespace ast_canopy {
+ParamVar::ParamVar(std::string name, Type type)
+    : name(std::move(name)), type(type) {}
+
 ParamVar::ParamVar(const clang::ParmVarDecl *PVD)
     : name(PVD->getNameAsString()), type(PVD->getType(), PVD->getASTContext()) {
 }

--- a/ast_canopy/cpp/src/record.cpp
+++ b/ast_canopy/cpp/src/record.cpp
@@ -26,20 +26,17 @@ Record::Record(const std::string &name, const std::vector<Field> &fields,
                const std::vector<Record> &nested_records,
                const std::vector<ClassTemplate> &nested_class_templates,
                const std::size_t &sizeof_, const std::size_t &alignof_,
-               const std::string &source_range)
-    : name(name), fields(fields), methods(methods),
-      templated_methods(templated_methods), nested_records(nested_records),
+               const std::string &source_range,
+               const std::vector<std::string> &namespace_stack)
+    : Declaration(namespace_stack), name(name), fields(fields),
+      methods(methods), templated_methods(templated_methods),
+      nested_records(nested_records),
       nested_class_templates(nested_class_templates), sizeof_(sizeof_),
       alignof_(alignof_), source_range(source_range) {}
 
 Record::Record(const clang::CXXRecordDecl *RD, RecordAncestor rp)
     : Declaration(RD) {
   using AS = clang::AccessSpecifier;
-
-#ifndef NDEBUG
-  source_range = RD->getSourceRange().printToString(
-      RD->getASTContext().getSourceManager());
-#endif
 
   name = RD->getNameAsString();
 
@@ -100,13 +97,15 @@ Record::Record(const clang::CXXRecordDecl *RD, RecordAncestor rp)
   }
 
 #ifndef NDEBUG
+  source_range = RD->getSourceRange().printToString(
+      RD->getASTContext().getSourceManager());
   print(0);
 #endif
 }
 
 Record::Record(const clang::CXXRecordDecl *RD, RecordAncestor rp,
                std::string name_override)
-    : Declaration(RD) {
+    : Record(RD, rp) {
   this->name = name_override;
 }
 

--- a/ast_canopy/cpp/src/record.cpp
+++ b/ast_canopy/cpp/src/record.cpp
@@ -20,6 +20,18 @@ std::size_t constexpr INVALID_SIZE_OF = std::numeric_limits<std::size_t>::max();
 std::size_t constexpr INVALID_ALIGN_OF =
     std::numeric_limits<std::size_t>::max();
 
+Record::Record(const std::string &name, const std::vector<Field> &fields,
+               const std::vector<Method> &methods,
+               const std::vector<FunctionTemplate> &templated_methods,
+               const std::vector<Record> &nested_records,
+               const std::vector<ClassTemplate> &nested_class_templates,
+               const std::size_t &sizeof_, const std::size_t &alignof_,
+               const std::string &source_range)
+    : name(name), fields(fields), methods(methods),
+      templated_methods(templated_methods), nested_records(nested_records),
+      nested_class_templates(nested_class_templates), sizeof_(sizeof_),
+      alignof_(alignof_), source_range(source_range) {}
+
 Record::Record(const clang::CXXRecordDecl *RD, RecordAncestor rp) {
   using AS = clang::AccessSpecifier;
 

--- a/ast_canopy/cpp/src/record.cpp
+++ b/ast_canopy/cpp/src/record.cpp
@@ -32,7 +32,8 @@ Record::Record(const std::string &name, const std::vector<Field> &fields,
       nested_class_templates(nested_class_templates), sizeof_(sizeof_),
       alignof_(alignof_), source_range(source_range) {}
 
-Record::Record(const clang::CXXRecordDecl *RD, RecordAncestor rp) {
+Record::Record(const clang::CXXRecordDecl *RD, RecordAncestor rp)
+    : Declaration(RD) {
   using AS = clang::AccessSpecifier;
 
 #ifndef NDEBUG
@@ -104,9 +105,9 @@ Record::Record(const clang::CXXRecordDecl *RD, RecordAncestor rp) {
 }
 
 Record::Record(const clang::CXXRecordDecl *RD, RecordAncestor rp,
-               std::string name)
-    : Record(RD, rp) {
-  this->name = name;
+               std::string name_override)
+    : Declaration(RD) {
+  this->name = name_override;
 }
 
 void Record::print(int level) const {

--- a/ast_canopy/cpp/src/type.cpp
+++ b/ast_canopy/cpp/src/type.cpp
@@ -99,4 +99,7 @@ Type::Type(const clang::QualType &qualtype, const clang::ASTContext &context) {
   _is_left_reference = ty->isLValueReferenceType();
 }
 
+bool Type::is_right_reference() const { return _is_right_reference; }
+bool Type::is_left_reference() const { return _is_left_reference; }
+
 } // namespace ast_canopy

--- a/ast_canopy/cpp/src/typedef.cpp
+++ b/ast_canopy/cpp/src/typedef.cpp
@@ -13,8 +13,10 @@
 
 namespace ast_canopy {
 
-Typedef::Typedef(const std::string &name, const std::string &underlying_name)
-    : name(name), underlying_name(underlying_name) {}
+Typedef::Typedef(const std::string &name, const std::string &underlying_name,
+                 const std::vector<std::string> &namespace_stack)
+    : Declaration(namespace_stack), name(name),
+      underlying_name(underlying_name) {}
 
 Typedef::Typedef(const clang::TypedefDecl *TD,
                  std::unordered_map<int64_t, std::string> *record_id_to_name)

--- a/ast_canopy/cpp/src/typedef.cpp
+++ b/ast_canopy/cpp/src/typedef.cpp
@@ -18,7 +18,7 @@ Typedef::Typedef(const std::string &name, const std::string &underlying_name)
 
 Typedef::Typedef(const clang::TypedefDecl *TD,
                  std::unordered_map<int64_t, std::string> *record_id_to_name)
-    : name(TD->getNameAsString()) {
+    : Declaration(TD), name(TD->getNameAsString()) {
   const clang::Type *type = TD->getUnderlyingType().getTypePtr();
   if (const clang::RecordType *RT = type->getAs<clang::RecordType>()) {
     if (const clang::CXXRecordDecl *RD = RT->getAsCXXRecordDecl()) {

--- a/ast_canopy/cpp/src/utils.cpp
+++ b/ast_canopy/cpp/src/utils.cpp
@@ -1,0 +1,32 @@
+// clang-format off
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// clang-format on
+
+#include <ast_canopy/utils.hpp>
+#include <clang/AST/Decl.h>
+
+namespace ast_canopy {
+
+std::vector<std::string> extract_namespace_stack(const clang::Decl *decl) {
+  std::vector<std::string> namespace_stack;
+
+  // Get the declaration context
+  const clang::DeclContext *context = decl->getDeclContext();
+
+  // Traverse up the context chain to collect namespaces
+  while (context) {
+    if (const clang::NamespaceDecl *ns =
+            clang::dyn_cast<clang::NamespaceDecl>(context)) {
+      // Skip anonymous namespaces
+      if (!ns->isAnonymousNamespace()) {
+        namespace_stack.push_back(ns->getNameAsString());
+      }
+    }
+    context = context->getParent();
+  }
+
+  return namespace_stack;
+}
+
+} // namespace ast_canopy

--- a/ast_canopy/cpp/src/utils.cpp
+++ b/ast_canopy/cpp/src/utils.cpp
@@ -18,8 +18,10 @@ std::vector<std::string> extract_namespace_stack(const clang::Decl *decl) {
   while (context) {
     if (const clang::NamespaceDecl *ns =
             clang::dyn_cast<clang::NamespaceDecl>(context)) {
-      // Skip anonymous namespaces
-      if (!ns->isAnonymousNamespace()) {
+      // For anonymous namespaces, add an empty string
+      if (ns->isAnonymousNamespace()) {
+        namespace_stack.push_back("");
+      } else {
         namespace_stack.push_back(ns->getNameAsString());
       }
     }

--- a/ast_canopy/tests/data/sample_namespace.cu
+++ b/ast_canopy/tests/data/sample_namespace.cu
@@ -1,0 +1,54 @@
+// clang-format off
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// clang-format on
+
+// 1. No namespace
+struct NoNamespaceStruct {
+  int x;
+  __device__ void foo() {}
+};
+
+template <typename T> __device__ void no_namespace_func(T x) {}
+
+// 2. Flat namespace
+namespace flat {
+struct FlatStruct {
+  int y;
+  __device__ void bar() {}
+};
+
+template <typename T> __device__ void flat_func(T x) {}
+
+enum FlatEnum { A = 1, B = 2 };
+} // namespace flat
+
+// 3. Nested namespace
+namespace outer {
+namespace inner {
+struct NestedStruct {
+  int z;
+  __device__ void baz() {}
+};
+
+template <typename T> __device__ void nested_func(T x) {}
+
+} // namespace inner
+} // namespace outer
+
+// 4. Nested namespace with anonymous namespace
+namespace {
+struct AnonymousStruct {
+  int w;
+  __device__ void qux() {}
+};
+} // namespace
+
+namespace outer {
+namespace {
+struct OuterAnonymousStruct {
+  int v;
+  __device__ void quux() {}
+};
+} // namespace
+} // namespace outer

--- a/ast_canopy/tests/test_parse_namespace.py
+++ b/ast_canopy/tests/test_parse_namespace.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from ast_canopy import parse_declarations_from_source
+
+
+@pytest.fixture(scope="module")
+def sample_namespace_source(data_folder):
+    return data_folder / "sample_namespace.cu"
+
+
+@pytest.fixture(scope="module")
+def decls(sample_namespace_source):
+    srcstr = str(sample_namespace_source)
+    return parse_declarations_from_source(
+        srcstr, [srcstr], "sm_80", verbose=True
+    )
+
+
+def test_no_namespace_declarations(decls):
+    """Test declarations with no namespace."""
+    # Test struct
+    no_ns_struct = next(
+        s for s in decls.structs if s.name == "NoNamespaceStruct"
+    )
+    assert no_ns_struct.namespace_stack == []
+    assert len(no_ns_struct.methods) == 1
+    assert no_ns_struct.methods[0].name == "foo"
+    assert no_ns_struct.methods[0].namespace_stack == []
+
+    # Test function template
+    no_ns_func = next(
+        f
+        for f in decls.function_templates
+        if f.function.name == "no_namespace_func"
+    )
+    assert no_ns_func.namespace_stack == []
+
+
+def test_flat_namespace_declarations(decls):
+    """Test declarations in a flat (single-level) namespace."""
+    # Test struct
+    flat_struct = next(s for s in decls.structs if s.name == "FlatStruct")
+    assert flat_struct.namespace_stack == ["flat"]
+    assert len(flat_struct.methods) == 1
+    assert flat_struct.methods[0].name == "bar"
+    assert flat_struct.methods[0].namespace_stack == ["flat"]
+
+    # Test function template
+    flat_func = next(
+        f for f in decls.function_templates if f.function.name == "flat_func"
+    )
+    assert flat_func.namespace_stack == ["flat"]
+
+    # Test enum
+    flat_enum = next(e for e in decls.enums if e.name == "FlatEnum")
+    assert flat_enum.namespace_stack == ["flat"]
+    assert len(flat_enum.enumerators) == 2
+    assert flat_enum.enumerators[0] == "A"
+    assert flat_enum.enumerators[1] == "B"
+
+
+def test_nested_namespace_declarations(decls):
+    """Test declarations in nested namespaces."""
+    # Test struct
+    nested_struct = next(s for s in decls.structs if s.name == "NestedStruct")
+    assert nested_struct.namespace_stack == ["inner", "outer"]
+    assert len(nested_struct.methods) == 1
+    assert nested_struct.methods[0].name == "baz"
+    assert nested_struct.methods[0].namespace_stack == ["inner", "outer"]
+
+    # Test function template
+    nested_func = next(
+        f for f in decls.function_templates if f.function.name == "nested_func"
+    )
+    assert nested_func.namespace_stack == ["inner", "outer"]
+
+
+def test_anonymous_namespace_declarations(decls):
+    """Test declarations in anonymous namespaces."""
+    # Test global anonymous namespace
+    anon_struct = next(s for s in decls.structs if s.name == "AnonymousStruct")
+    assert anon_struct.namespace_stack == [
+        ""
+    ]  # Anonymous namespace is represented as empty string
+
+    # Test anonymous namespace nested in outer namespace
+    outer_anon_struct = next(
+        s for s in decls.structs if s.name == "OuterAnonymousStruct"
+    )
+    assert outer_anon_struct.namespace_stack == [
+        "",
+        "outer",
+    ]  # Anonymous namespace in outer namespace


### PR DESCRIPTION
- **add namespace_stack common attr**
- **move function definitions to cpp**
- **use a common base class named declaration**
- **add python binding and python test case**
