### PR TITLE
Use function mangled name to deduplicate forward declared function decls

### DIFF
--- a/numbast/src/numbast/errors.py
+++ b/numbast/src/numbast/errors.py
@@ -23,3 +23,19 @@ class TypeNotFoundError(BaseASTError):
     @property
     def type_name(self):
         return self._type_name
+
+
+class MangledFunctionNameConflictError(BaseASTError):
+    """Indicate that a mangled function name is not unique.
+
+    This error is raised when a function with the same mangled name of a previously
+    generated binding is found.
+    """
+
+    def __init__(self, mangled_name: str):
+        self._mangled_name = mangled_name
+        super().__init__(f"Mangled function name {mangled_name} is not unique.")
+
+    @property
+    def mangled_name(self):
+        return self._mangled_name

--- a/numbast/src/numbast/static/struct.py
+++ b/numbast/src/numbast/static/struct.py
@@ -178,10 +178,7 @@ def {lower_scope_name}(shim_stream, shim_obj):
         )
 
         # Cache the unique shim name
-        shim_func_name = (
-            f"__{self._struct_name}__{self._ctor_decl.mangled_name}"
-        )
-        self._deduplicated_shim_name = deduplicate_overloads(shim_func_name)
+        self._deduplicated_shim_name = f"{self._ctor_decl.mangled_name}_nbst"
 
         # device caller name
         self._device_caller_name = f"{self._struct_name}_device_caller"

--- a/numbast/src/numbast/static/tests/data/conflict_func_name_1.cuh
+++ b/numbast/src/numbast/static/tests/data/conflict_func_name_1.cuh
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // clang-format on
 
+#pragma once
+
 struct Foo {
   Foo() = default;
 };

--- a/numbast/src/numbast/static/tests/data/conflict_func_name_2.cuh
+++ b/numbast/src/numbast/static/tests/data/conflict_func_name_2.cuh
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // clang-format on
 
+#pragma once
+
 struct Bar {
   Bar() = default;
 };

--- a/numbast/src/numbast/static/tests/data/multiple_decls.cuh
+++ b/numbast/src/numbast/static/tests/data/multiple_decls.cuh
@@ -1,0 +1,12 @@
+// clang-format off
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// clang-format on
+
+#pragma once
+
+void __device__ __forceinline__ foo(int a, int b);
+
+void __device__ __forceinline__ foo(int a, int b);
+
+void __device__ __forceinline__ foo(int a, int b) { return; }

--- a/numbast/src/numbast/static/tests/test_multiple_decls.py
+++ b/numbast/src/numbast/static/tests/test_multiple_decls.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import re
+
+from numba import cuda
+
+
+def test_multiple_decls(make_binding):
+    res1 = make_binding("multiple_decls.cuh", {}, {})
+    binding = res1["bindings"]
+    src = res1["src"]
+
+    with open("/tmp/test.py", "w") as f:
+        f.write(src)
+
+    pat = r"def _lower_\w+_nbst\(shim_stream, shim_obj\):"
+    matches = re.findall(pat, src)
+    assert len(matches) == 1, "Expected exactly one lower function"
+
+    lower_func_name = matches[0]
+    assert "_lower__Z3fooii_nbst" in lower_func_name, (
+        "Expected _lower__Z3fooii_nbst"
+    )
+
+    foo = binding["foo"]
+
+    @cuda.jit
+    def kernel():
+        foo(1, 2)
+
+    kernel[1, 1]()

--- a/numbast/src/numbast/static/tests/test_multiple_decls.py
+++ b/numbast/src/numbast/static/tests/test_multiple_decls.py
@@ -11,9 +11,6 @@ def test_multiple_decls(make_binding):
     binding = res1["bindings"]
     src = res1["src"]
 
-    with open("/tmp/test.py", "w") as f:
-        f.write(src)
-
     pat = r"def _lower_\w+_nbst\(shim_stream, shim_obj\):"
     matches = re.findall(pat, src)
     assert len(matches) == 1, "Expected exactly one lower function"


### PR DESCRIPTION
This PR makes use of the `mangled_name` attribute added in #139 to remove duplicate declarations due to forward declarations in C++.

Currently, because we use a crude manner to track the number of bindings created for each function, there can be duplicates if multiple forward declarations are found from the code base. This is not ideal as it bloats the binding file size. This PR make uses of mangled name, which *uniquely distinguishes* functions that have the same function signature in the same scope, effectively removing duplicate bindings created for forward declarations.