### PR TITLE
Add Prefix Remover for Functions in Static Binding Generator

### DIFF
--- a/numbast/src/numbast/tools/tests/config/prefix_removal.yml.j2
+++ b/numbast/src/numbast/tools/tests/config/prefix_removal.yml.j2
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+Name: Test Data
+Version: 0.0.1
+Entry Point: {{ data }}
+File List:
+    - {{ data }}
+Exclude: {}
+Types:
+    Foo: Type
+Data Models:
+    Foo: StructModel
+API Prefix Removal:
+    Function:
+        - prefix_

--- a/numbast/src/numbast/tools/tests/prefix_removal.cuh
+++ b/numbast/src/numbast/tools/tests/prefix_removal.cuh
@@ -1,0 +1,6 @@
+// clang-format off
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// clang-format on
+
+int __device__ prefix_foo(int a, int b) { return a + b; }

--- a/numbast/src/numbast/tools/tests/test_prefix_removal.py
+++ b/numbast/src/numbast/tools/tests/test_prefix_removal.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import subprocess
+import sys
+
+
+def test_prefix_removal(run_in_isolated_folder):
+    """Test that API prefix removal works correctly for function names."""
+    res = run_in_isolated_folder(
+        "prefix_removal.yml.j2",
+        "prefix_removal.cuh",
+        {},
+        load_symbols=True,
+        ruff_format=False,
+    )
+
+    run_result = res["result"]
+    output_folder = res["output_folder"]
+    symbols = res["symbols"]
+    alls = symbols["__all__"]
+
+    assert run_result.exit_code == 0
+
+    # Verify that the function is exposed as "foo" (without the "prefix_" prefix)
+    assert "foo" in alls, f"Expected 'foo' in __all__, got: {alls}"
+
+    # Verify that the original name "prefix_foo" is NOT exposed
+    assert "prefix_foo" not in alls, (
+        f"Expected 'prefix_foo' NOT in __all__, got: {alls}"
+    )
+
+    # Test that the function can be imported and used as "foo"
+    test_kernel_src = """
+from numba import cuda
+from prefix_removal import foo
+
+@cuda.jit
+def kernel():
+    result = foo(1, 2)  # Verify that prefix_foo is accessible as foo
+
+kernel[1, 1]()
+"""
+
+    test_kernel = os.path.join(output_folder, "test.py")
+    with open(test_kernel, "w") as f:
+        f.write(test_kernel_src)
+
+    res = subprocess.run(
+        [sys.executable, test_kernel],
+        cwd=output_folder,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+    assert res.returncode == 0, res.stdout.decode("utf-8")


### PR DESCRIPTION
This PR adds a prefix remover item to config file. Any prefix specified in this list will be removed from the generated bindings for functions.

Note this is for function only, support for record maybe added in the future should there be a RFE.