### PR TITLE
Fix a Bug where GlobalDecl is constructed mistakenly when performing name mangles

### DIFF
--- a/ast_canopy/cpp/src/function.cpp
+++ b/ast_canopy/cpp/src/function.cpp
@@ -10,6 +10,7 @@
 #include <ast_canopy/ast_canopy.hpp>
 
 #include <algorithm>
+#include <iostream>
 
 namespace ast_canopy {
 
@@ -43,7 +44,19 @@ Function::Function(const clang::FunctionDecl *FD)
   clang::ItaniumMangleContext *MC =
       clang::ItaniumMangleContext::create(context, diag);
   llvm::raw_string_ostream OS(mangled_name);
-  MC->mangleName(FD, OS);
+
+  clang::GlobalDecl GD;
+  if (const clang::CXXConstructorDecl *CCD =
+          clang::dyn_cast<clang::CXXConstructorDecl>(FD)) {
+    GD = clang::GlobalDecl(CCD, clang::Ctor_Complete);
+  } else if (const clang::CXXDestructorDecl *CDD =
+                 clang::dyn_cast<clang::CXXDestructorDecl>(FD)) {
+    GD = clang::GlobalDecl(CDD, clang::Dtor_Complete);
+  } else {
+    GD = clang::GlobalDecl(FD);
+  }
+
+  MC->mangleName(GD, OS);
   OS.flush();
 }
 } // namespace ast_canopy

--- a/ast_canopy/tests/data/sample_itanium_mangled_names.cu
+++ b/ast_canopy/tests/data/sample_itanium_mangled_names.cu
@@ -4,20 +4,24 @@
 // clang-format on
 
 struct Foo {
-  Foo() = default;
+  __device__ Foo() = default;
+  __device__ Foo(int a) : a(a) {}
+  int a;
 };
 
 struct Bar {
-  Bar() = default;
+  __device__ Bar() = default;
+  __device__ Bar(int a) : a(a) {}
+  int a;
 };
 
-Foo operator+(const Foo &a, const Foo &b) { return Foo(); }
-Bar operator+(const Bar &a, const Bar &b) { return Bar(); }
+__device__ Foo operator+(const Foo &a, const Foo &b) { return Foo(); }
+__device__ Bar operator+(const Bar &a, const Bar &b) { return Bar(); }
 
 namespace ns1 {
-int inner_func(Foo a, Bar b) { return 0; }
+__device__ int inner_func(Foo a, Bar b) { return 0; }
 } // namespace ns1
 
 namespace ns2 {
-int inner_func(Foo a, Bar b) { return 0; }
+__device__ int inner_func(Foo a, Bar b) { return 0; }
 } // namespace ns2

--- a/ast_canopy/tests/test_mangled_name.py
+++ b/ast_canopy/tests/test_mangled_name.py
@@ -29,10 +29,14 @@ def test_itanium_mangled_name(decls):
     assert structs[1].name == "Bar"
 
     assert structs[0].methods[0].name == "Foo"
+    assert structs[0].methods[1].name == "Foo"
     assert structs[1].methods[0].name == "Bar"
+    assert structs[1].methods[1].name == "Bar"
 
     assert structs[0].methods[0].mangled_name == "_ZN3FooC1Ev"
+    assert structs[0].methods[1].mangled_name == "_ZN3FooC1Ei"
     assert structs[1].methods[0].mangled_name == "_ZN3BarC1Ev"
+    assert structs[1].methods[1].mangled_name == "_ZN3BarC1Ei"
 
     assert functions[0].name == "operator+"
     assert functions[1].name == "operator+"

--- a/conda/environment.yaml
+++ b/conda/environment.yaml
@@ -10,7 +10,7 @@ channels:
 dependencies:
   - python>=3.10
   - cmake>=3.28 # >=3.28 is more reliable in detecting CUDAToolkit.
-  - clangdev>=19
+  - clangdev>=18
   - numba-cuda >=0.16
   - pybind11
   - pytest

--- a/conda/environment_template.yaml
+++ b/conda/environment_template.yaml
@@ -10,7 +10,7 @@ channels:
 dependencies:
   - python={{ python_version }}
   - cmake>=3.28 # >=3.28 is more reliable in detecting CUDAToolkit.
-  - clangdev>=19
+  - clangdev>=18
   - numba-cuda >=0.16
   - pybind11
   - pytest

--- a/conda/recipes/ast_canopy/meta.yaml
+++ b/conda/recipes/ast_canopy/meta.yaml
@@ -45,7 +45,7 @@ requirements:
     - pybind11
     - pip
     - scikit-build-core
-    - clangdev >=19
+    - clangdev >=18
     - llvmdev >=14
     - llvm >=14
   run:

--- a/conda/recipes/ast_canopy/meta.yaml
+++ b/conda/recipes/ast_canopy/meta.yaml
@@ -52,7 +52,7 @@ requirements:
     - cuda-version >=12.5
     - cuda-nvcc >=12.5
     - python
-    - clangdev >=19
+    - clangdev >=18
     # libcurand-dev contains `curand_mtgp32_kernel.h`, which is needed by clang
     # CUDA mode to function properly. See:
     # https://clang.llvm.org/doxygen/____clang__cuda__runtime__wrapper_8h_source.html


### PR DESCRIPTION
In #145 we bumped the clangdev version to 19, which originally was thought to be a solution to a segfault to the name mangling on a `CXXConstructorDecl` node. However, later troubleshooting shows that the issue is caused by the `GlobalDecl` node is constructed with the wrong constructor. When creating a `GlobalDecl` from a ctor decl node, it should explicitly specify the `CXXCtorType` in argument. In our most common use case, we use `Ctor_Complete` for most cases.

This PR reverts the minimum clangdev pinning back to 18 as it turns out to be irrelevant to the cause of crash.