### PR TITLE
Configure static binding CC via `GPU Arch` Entry

### DIFF
--- a/ast_canopy/ast_canopy/api.py
+++ b/ast_canopy/ast_canopy/api.py
@@ -6,7 +6,7 @@ import shutil
 import os
 import tempfile
 import logging
-from typing import Optional
+from typing import Optional, Any
 from dataclasses import dataclass
 
 from numba.cuda.cuda_paths import get_nvidia_nvvm_ctk, get_cuda_home
@@ -225,6 +225,8 @@ def parse_declarations_from_source(
         if not os.path.exists(p):
             raise FileNotFoundError(f"Additional include path not found: {p}")
 
+    _validate_compute_capability(compute_capability)
+
     if cccl_root:
         cccl_libs = [
             os.path.join(cccl_root, "libcudacxx", "include"),
@@ -375,3 +377,26 @@ def value_from_constexpr_vardecl(
             ConstExprVar.from_c_obj(c_result) if c_result is not None else None
         )
         return result
+
+
+def _validate_compute_capability(compute_capability: Any):
+    """Validate the compute capability string.
+
+    Parameters
+    ----------
+    compute_capability : Any
+        The compute capability string to validate.
+    """
+    if not isinstance(compute_capability, str):
+        raise TypeError(
+            f"Compute capability must be a string: {compute_capability}"
+        )
+
+    if not compute_capability.startswith("sm_"):
+        raise ValueError(
+            f"Compute capability must start with 'sm_': {compute_capability}"
+        )
+    if not compute_capability[3:].isdigit():
+        raise ValueError(
+            f"Compute capability must be in the form of 'sm_<compute_capability>': {compute_capability}"
+        )

--- a/ast_canopy/cpp/src/ast_canopy.cpp
+++ b/ast_canopy/cpp/src/ast_canopy.cpp
@@ -81,6 +81,10 @@ Declarations parse_declarations_from_command_line(
 
   auto ast = detail::default_ast_unit_from_command_line(options);
 
+  if (!ast) {
+    throw std::runtime_error("Failed to create an ASTUnit pointer.");
+  }
+
   Declarations decls;
   std::unordered_map<int64_t, std::string> record_id_to_name;
   std::unordered_set<int64_t> record_id_with_ctpsd_ancestor;

--- a/numbast/src/numbast/static/tests/conftest.py
+++ b/numbast/src/numbast/static/tests/conftest.py
@@ -33,10 +33,11 @@ def make_binding(tmpdir, data_folder):
         cfg = Config.from_params(
             entry_point=header_path,
             retain_list=[header_path],
+            gpu_arch=[cc],
             types=types,
             datamodels=datamodels,
         )
-        _static_binding_generator(cfg, tmpdir, cc)
+        _static_binding_generator(cfg, tmpdir)
 
         basename = header_name.split(".")[0]
         with open(tmpdir / f"{basename}.py") as f:

--- a/numbast/src/numbast/tools/static_binding_generator.py
+++ b/numbast/src/numbast/tools/static_binding_generator.py
@@ -13,7 +13,7 @@ import re
 
 import yaml
 
-from numba import config, cuda
+from numba import config
 from numba.cuda import cuda_paths
 import numba.types
 import numba.core.datamodel.models
@@ -47,8 +47,6 @@ if include_dir is None:
     raise ValueError("Unable to find CUDAToolkit include directory")
 CUDA_INCLUDE_PATH = include_dir.info
 
-MACHINE_COMPUTE_CAPABILITY = cuda.get_current_device().compute_capability
-
 # Register custom YAML constructor for !join tag
 yaml.add_constructor("!numbast_join", string_constructor)
 
@@ -56,52 +54,57 @@ yaml.add_constructor("!numbast_join", string_constructor)
 class Config:
     """Configuration File for Static Binding Generation.
 
-    Attributes
-    ----------
-    entry_point : str
-        Path to the input CUDA header file.
-    retain_list : list[str]
-        List of file names to keep parsing. The list of files from which the
-        declarations are retained in the final generated binding output. Bindings
-        that exist in other source, which may get transitively included in the
-        declaration, are ignored in bindings output.
-    types : dict[str, type]
-        A dictionary that maps struct names to their Numba types.
-    datamodels : dict[str, type]
-        A dictionary that maps struct names to their Numba data models.
+     Attributes
+     ----------
+     entry_point : str
+         Path to the input CUDA header file.
+     gpu_arch: list[str]
+         The list of GPU architectures to generate bindings for. Currently, only
+         one architecture per run is supported. Must be under pattern
+         `sm_<compute_capability>`. Required.
+     retain_list : list[str]
+         List of file names to keep parsing. The list of files from which the
+         declarations are retained in the final generated binding output. Bindings
+         that exist in other source, which may get transitively included in the
+         declaration, are ignored in bindings output.
+     types : dict[str, type]
+         A dictionary that maps struct names to their Numba types.
+     datamodels : dict[str, type]
+         A dictionary that maps struct names to their Numba data models.
     exclude_functions : list[str]
-        List of function names to exclude from the bindings.
-    exclude_structs : list[str]
-        List of struct names to exclude from the bindings.
-    clang_includes_paths : list[str]
-        List of additional include paths to use when parsing the header file.
-    macro_expanded_function_prefixes : list[str]
-        List of prefixes to allow for anonymous filename declarations.
-    additional_imports : list[str]
-        The list of additional imports to add to the binding file.
-    shim_include_override : str | None
-        Override the include line of the shim function to specified string.
-        If not specified, default to `#include <path_to_entry_point>`.
-    require_pynvjitlink : bool
-        If true, detect if pynvjitlink is installed, raise an error if not.
-    predefined_macros : list[str]
-        List of macros defined prior to parsing the header and prefixing shim functions.
-    output_name : str | None
-        The name of the output binding file, default None. When set to None, use
-        the same name as input file (renamed with .py extension).
-    cooperative_launch_required_functions_regex : list[str]
-        The list of regular expressions. When any function name matches any of these
-        regex patterns, the function should cause the kernel to be launched with
-        cooperative launch.
-    api_prefix_removal : dict[str, list[str]]
-        Dictionary mapping declaration types to lists of prefixes to remove from names.
-        For example, {"Function": ["prefix_"]} would remove "prefix_" from function names.
-    module_callbacks : dict[str, str]
-        Dictionary containing setup and teardown callbacks for the module.
-        Expected keys: "setup", "teardown". Each value is a string callback function.
+         List of function names to exclude from the bindings.
+     exclude_structs : list[str]
+         List of struct names to exclude from the bindings.
+     clang_includes_paths : list[str]
+         List of additional include paths to use when parsing the header file.
+     macro_expanded_function_prefixes : list[str]
+         List of prefixes to allow for anonymous filename declarations.
+     additional_imports : list[str]
+         The list of additional imports to add to the binding file.
+     shim_include_override : str | None
+         Override the include line of the shim function to specified string.
+         If not specified, default to `#include <path_to_entry_point>`.
+     require_pynvjitlink : bool
+         If true, detect if pynvjitlink is installed, raise an error if not.
+     predefined_macros : list[str]
+         List of macros defined prior to parsing the header and prefixing shim functions.
+     output_name : str | None
+         The name of the output binding file, default None. When set to None, use
+         the same name as input file (renamed with .py extension).
+     cooperative_launch_required_functions_regex : list[str]
+         The list of regular expressions. When any function name matches any of these
+         regex patterns, the function should cause the kernel to be launched with
+         cooperative launch.
+     api_prefix_removal : dict[str, list[str]]
+         Dictionary mapping declaration types to lists of prefixes to remove from names.
+         For example, {"Function": ["prefix_"]} would remove "prefix_" from function names.
+     module_callbacks : dict[str, str]
+         Dictionary containing setup and teardown callbacks for the module.
+         Expected keys: "setup", "teardown". Each value is a string callback function.
     """
 
     entry_point: str
+    gpu_arch: list[str]
     retain_list: list[str]
     types: dict[str, type]
     datamodels: dict[str, type]
@@ -127,6 +130,7 @@ class Config:
             Dictionary containing configuration values.
         """
         self.entry_point = config_dict["Entry Point"]
+        self.gpu_arch = config_dict["GPU Arch"]
         self.retain_list = config_dict["File List"]
         self.types = _str_value_to_numba_type(config_dict.get("Types", {}))
         self.datamodels = _str_value_to_numba_datamodel(
@@ -178,6 +182,12 @@ class Config:
 
         self.module_callbacks = config_dict.get("Module Callbacks", {})
 
+        # TODO: support multiple GPU architectures
+        if len(self.gpu_arch) > 1:
+            raise NotImplementedError(
+                "Multiple GPU architectures are not supported yet."
+            )
+
         self._verify_exists()
         self._verify_regex_patterns()
 
@@ -203,6 +213,7 @@ class Config:
     def from_params(
         cls,
         entry_point: str,
+        gpu_arch: list[str],
         retain_list: list[str],
         types: dict[str, type],
         datamodels: dict[str, type],
@@ -227,6 +238,7 @@ class Config:
 
         config_dict = {
             "Entry Point": entry_point,
+            "GPU Arch": gpu_arch,
             "File List": retain_list,
             "Types": {},
             "Data Models": {},
@@ -446,7 +458,6 @@ def log_files_to_generate(
 def _static_binding_generator(
     config: Config,
     output_dir: str,
-    compute_capability: str,
     log_generates: bool = False,
     cfg_file_path: str | None = None,
     sbg_params: dict[str, str] = {},
@@ -475,6 +486,15 @@ def _static_binding_generator(
 
     entry_point = os.path.abspath(config.entry_point)
     retain_list = [os.path.abspath(path) for path in config.retain_list]
+
+    if len(config.gpu_arch) == 0:
+        raise ValueError("At least one GPU architecture must be provided.")
+    elif len(config.gpu_arch) > 1:
+        raise NotImplementedError(
+            "Multiple GPU architectures are not supported yet."
+        )
+
+    compute_capability = config.gpu_arch[0]
 
     # TODO: we don't have tests on different compute capabilities for the static binding generator yet.
     # This will be added in future PRs.
@@ -599,13 +619,6 @@ def ruff_format_binding_file(binding_file_path: str):
 @click.command()
 @click.pass_context
 @click.option(
-    "--entry-point",
-    type=click.Path(exists=True, dir_okay=False, readable=True),
-)
-@click.option("--retain")
-@click.option("--types", type=numba_type_dict)
-@click.option("--datamodels", type=numba_datamodel_dict)
-@click.option(
     "--cfg-path", type=click.Path(exists=True, dir_okay=False, readable=True)
 )
 @click.option(
@@ -618,11 +631,6 @@ def ruff_format_binding_file(binding_file_path: str):
     required=True,
 )
 @click.option(
-    "--compute-capability",
-    type=str,
-    default=None,
-)
-@click.option(
     "-fmt",
     "--run-ruff-format",
     type=bool,
@@ -630,83 +638,31 @@ def ruff_format_binding_file(binding_file_path: str):
 )
 def static_binding_generator(
     ctx,
-    entry_point,
-    retain,
     cfg_path,
     output_dir,
-    types,
-    datamodels,
-    compute_capability,
     run_ruff_format,
 ):
     """
     A CLI tool to generate CUDA static bindings for CUDA C++ headers.
 
-    ENTRY POINT: Path to the input CUDA header file.
-    CFG_PATH: Path to the configuration file in YAML format. If specified, only COMPUTE_CAPABILITY and OUTPUT_DIR is allowed as parameter.
-    RETAIN: Comma separated list of file names to keep parsing, default to ENTRY POINT.
+    CFG_PATH: Path to the configuration file in YAML format.
     OUTPUT_DIR: Path to the output directory where the processed files will be saved.
-    TYPES: A dictionary in JSON string that maps name of the struct to their Numba type.
-    DATAMODELS: A dictionary in JSON string that maps name of the struct to their Numba datamodel.
-    COMPUTE_CAPABILITY: Compute capability of the CUDA device, default to the current machine's compute capability.
     RUN_RUFF_FORMAT: Run ruff format on the generated binding file.
     """
     reset_renderer()
 
-    if compute_capability is None:
-        compute_capability = (
-            f"sm_{MACHINE_COMPUTE_CAPABILITY[0]}{MACHINE_COMPUTE_CAPABILITY[1]}"
-        )
-
-    if not compute_capability.startswith("sm_"):
-        raise ValueError("Compute capability must start with `sm_`")
-
-    if cfg_path:
-        if any(x is not None for x in [entry_point, retain, types, datamodels]):
-            raise ValueError(
-                "When CFG_PATH specified, none of INPUT_HEADER, RETAIN, TYPES and DATAMODELS should be specified."
-            )
-
-        cfg = Config.from_yaml_path(cfg_path)
-        output_file = _static_binding_generator(
-            cfg,
-            output_dir,
-            compute_capability,
-            log_generates=True,
-            cfg_file_path=cfg_path,
-            sbg_params=ctx.params,
-        )
-
-        if run_ruff_format:
-            spec = importlib.util.find_spec("ruff")
-            if spec is None:
-                warnings.warn("Ruff is not on the system. Formatting skipped.")
-            else:
-                ruff_format_binding_file(output_file)
-
-        return
-
-    if retain is None:
-        retain_list = [entry_point]
-    else:
-        retain_list = retain.split(",")
-
-    if len(retain_list) == 0:
-        raise ValueError("At least one file name to retain must be provided.")
-
-    cfg = Config.from_params(
-        entry_point=entry_point,
-        retain_list=retain_list,
-        types=types or {},
-        datamodels=datamodels or {},
-    )
-
+    cfg = Config.from_yaml_path(cfg_path)
     output_file = _static_binding_generator(
         cfg,
         output_dir,
-        compute_capability,
         log_generates=True,
+        cfg_file_path=cfg_path,
+        sbg_params=ctx.params,
     )
 
     if run_ruff_format:
-        ruff_format_binding_file(output_file)
+        spec = importlib.util.find_spec("ruff")
+        if spec is None:
+            warnings.warn("Ruff is not on the system. Formatting skipped.")
+        else:
+            ruff_format_binding_file(output_file)

--- a/numbast/src/numbast/tools/tests/config/cc.yml.j2
+++ b/numbast/src/numbast/tools/tests/config/cc.yml.j2
@@ -1,0 +1,12 @@
+Name: Test Data
+Version: 0.0.1
+Entry Point: {{ data }}
+GPU Arch:
+    - {{ arch_str }}
+File List:
+    - {{ data }}
+Exclude: {}
+Types:
+    Foo: Type
+Data Models:
+    Foo: StructModel

--- a/numbast/src/numbast/tools/tests/config/cfg.yml.j2
+++ b/numbast/src/numbast/tools/tests/config/cfg.yml.j2
@@ -1,6 +1,8 @@
 Name: Test Data
 Version: 0.0.1
 Entry Point: {{ data }}
+GPU Arch:
+    - {{ arch_str }}
 File List:
     - {{ data }}
 Exclude: {}

--- a/numbast/src/numbast/tools/tests/config/cooperative_launch.yml.j2
+++ b/numbast/src/numbast/tools/tests/config/cooperative_launch.yml.j2
@@ -1,6 +1,8 @@
 Name: Cooperative Launch
 Version: 0.0.1
 Entry Point: {{ data }}
+GPU Arch:
+    - {{ arch_str }}
 File List:
     - {{ data }}
 Exclude: {}

--- a/numbast/src/numbast/tools/tests/config/cooperative_launch_invalid_regex.yml.j2
+++ b/numbast/src/numbast/tools/tests/config/cooperative_launch_invalid_regex.yml.j2
@@ -1,6 +1,8 @@
 Name: Cooperative Launch Invalid Regex
 Version: 0.0.1
 Entry Point: {{ data }}
+GPU Arch:
+    - {{ arch_str }}
 File List:
     - {{ data }}
 Exclude: {}

--- a/numbast/src/numbast/tools/tests/config/cooperative_launch_regex.yml.j2
+++ b/numbast/src/numbast/tools/tests/config/cooperative_launch_regex.yml.j2
@@ -1,6 +1,8 @@
 Name: Cooperative Launch Regex
 Version: 0.0.1
 Entry Point: {{ data }}
+GPU Arch:
+    - {{ arch_str }}
 File List:
     - {{ data }}
 Exclude: {}

--- a/numbast/src/numbast/tools/tests/config/module_callbacks.yml.j2
+++ b/numbast/src/numbast/tools/tests/config/module_callbacks.yml.j2
@@ -4,6 +4,8 @@
 Name: Test Data
 Version: 0.0.1
 Entry Point: {{ data }}
+GPU Arch:
+    - {{ arch_str }}
 File List:
     - {{ data }}
 Exclude: {}

--- a/numbast/src/numbast/tools/tests/config/output_name.yml.j2
+++ b/numbast/src/numbast/tools/tests/config/output_name.yml.j2
@@ -1,6 +1,8 @@
 Name: Test Data
 Version: 0.0.1
 Entry Point: {{ data }}
+GPU Arch:
+    - {{ arch_str }}
 File List:
     - {{ data }}
 Exclude: {}

--- a/numbast/src/numbast/tools/tests/config/predefined_macros.yml.j2
+++ b/numbast/src/numbast/tools/tests/config/predefined_macros.yml.j2
@@ -1,6 +1,8 @@
 Name: Test Data
 Version: 0.0.1
 Entry Point: {{ data }}
+GPU Arch:
+    - {{ arch_str }}
 File List:
     - {{ data }}
 Exclude: {}

--- a/numbast/src/numbast/tools/tests/config/prefix_removal.yml.j2
+++ b/numbast/src/numbast/tools/tests/config/prefix_removal.yml.j2
@@ -4,6 +4,8 @@
 Name: Test Data
 Version: 0.0.1
 Entry Point: {{ data }}
+GPU Arch:
+    - {{ arch_str }}
 File List:
     - {{ data }}
 Exclude: {}

--- a/numbast/src/numbast/tools/tests/config/require_pynvjitlink.yml.j2
+++ b/numbast/src/numbast/tools/tests/config/require_pynvjitlink.yml.j2
@@ -4,6 +4,8 @@
 Name: Test Data
 Version: 0.0.1
 Entry Point: {{ data }}
+GPU Arch:
+    - {{ arch_str }}
 File List:
     - {{ data }}
 Exclude: {}

--- a/numbast/src/numbast/tools/tests/config/shim_include_override.yml.j2
+++ b/numbast/src/numbast/tools/tests/config/shim_include_override.yml.j2
@@ -1,6 +1,8 @@
 Name: Test Data
 Version: 0.0.1
 Entry Point: {{ data }}
+GPU Arch:
+    - {{ arch_str }}
 File List:
     - {{ data }}
 Exclude: {}

--- a/numbast/src/numbast/tools/tests/conftest.py
+++ b/numbast/src/numbast/tools/tests/conftest.py
@@ -7,6 +7,8 @@ import warnings
 
 import pytest
 
+from numba import cuda
+
 from jinja2 import Environment, FileSystemLoader
 
 from click.testing import CliRunner
@@ -105,3 +107,9 @@ def run_in_isolated_folder(tmpdir):
         }
 
     return _run
+
+
+@pytest.fixture
+def arch_str():
+    arch = cuda.get_current_device().compute_capability
+    return f"sm_{arch[0]}{arch[1]}"

--- a/numbast/src/numbast/tools/tests/test_additional_includes.py
+++ b/numbast/src/numbast/tools/tests/test_additional_includes.py
@@ -44,7 +44,7 @@ def patch_extra_include_paths():
 
 
 def test_cli_yml_inputs_additional_includes(
-    tmpdir, kernel, patch_extra_include_paths
+    tmpdir, kernel, patch_extra_include_paths, arch_str
 ):
     name = "additional_include"
     subdir = tmpdir.mkdir("sub")
@@ -55,6 +55,8 @@ Version: 0.0.1
 Entry Point: {data}
 File List:
     - {data}
+GPU Arch:
+    - {arch_str}
 Exclude: {{}}
 Types: {{}}
 Data Models: {{}}
@@ -72,8 +74,6 @@ Clang Include Paths:
         [
             "--cfg-path",
             cfg_file,
-            "--compute-capability",
-            "sm_50",
             "--output-dir",
             subdir,
         ],

--- a/numbast/src/numbast/tools/tests/test_cc.py
+++ b/numbast/src/numbast/tools/tests/test_cc.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+
+@pytest.mark.parametrize("cc, expected", [("sm_80", False), ("sm_90", True)])
+def test_cc_generated(run_in_isolated_folder, cc, expected):
+    res = run_in_isolated_folder(
+        "cfg.yml.j2",
+        "data.cuh",
+        {"arch_str": cc},
+        ruff_format=False,
+        load_symbols=True,
+    )
+
+    result = res["result"]
+    symbols = res["symbols"]
+
+    assert result.exit_code == 0
+
+    assert ("mul" in symbols) == expected

--- a/numbast/src/numbast/tools/tests/test_cli.py
+++ b/numbast/src/numbast/tools/tests/test_cli.py
@@ -136,9 +136,7 @@ Data Models:
 @pytest.mark.parametrize(
     "cc, expected", [("sm_70", False), ("sm_86", True), ("sm_90", True)]
 )
-def test_cli_yml_inputs_full_spec_with_cc(
-    tmpdir, kernel, cc, expected, arch_str
-):
+def test_cli_yml_inputs_full_spec_with_cc(tmpdir, cc, expected):
     clear_base_renderer_cache()
     clear_function_apis_registry()
 

--- a/numbast/src/numbast/tools/tests/test_cli.py
+++ b/numbast/src/numbast/tools/tests/test_cli.py
@@ -35,43 +35,6 @@ def kernel():
 
 
 @pytest.mark.parametrize(
-    "inputs",
-    [
-        ["/tmp/non_existing.cuh"],
-        [
-            os.path.join(os.path.dirname(__file__), "data.cuh"),
-            "--output-dir",
-            "/tmp/non_existing/",
-        ],
-        [
-            os.path.join(os.path.dirname(__file__), "data.cuh"),
-            "--output-dir",
-            "/tmp/",
-            "--types",
-            "invalid_type_string",
-        ],
-        [
-            os.path.join(os.path.dirname(__file__), "data.cuh"),
-            "--output-dir",
-            "/tmp/",
-            "--types",
-            '{"Foo":"Type"}',
-            "--datamodels",
-            "invalid_datamodel_string",
-        ],
-    ],
-)
-def test_invalid_input_header(inputs):
-    clear_base_renderer_cache()
-    clear_function_apis_registry()
-
-    runner = CliRunner()
-    with pytest.raises(Exception):
-        result = runner.invoke(static_binding_generator, inputs)
-        assert result.exit_code == 0
-
-
-@pytest.mark.parametrize(
     "args",
     [
         ["--entry-point", "data.cuh"],
@@ -79,7 +42,7 @@ def test_invalid_input_header(inputs):
         ["--datamodels", '{"Foo": "StructModel"}'],
     ],
 )
-def test_cli_yml_invalid_inputs(tmpdir, args):
+def test_cli_yml_invalid_inputs(tmpdir, args, arch_str):
     clear_base_renderer_cache()
     clear_function_apis_registry()
 
@@ -91,6 +54,8 @@ Version: 0.0.1
 Entry Point: {data}
 File List:
     - {data}
+GPU Arch:
+    - {arch_str}
 Exclude: []
 Types:
     Foo: Type
@@ -118,37 +83,7 @@ Data Models:
         assert result.exit_code == 0
 
 
-@pytest.mark.skip("TODO: A C++ error is thrown.")
-def test_simple_cli_empty_retain(tmpdir):
-    clear_base_renderer_cache()
-    clear_function_apis_registry()
-
-    subdir = tmpdir.mkdir("sub3")
-    data = os.path.join(os.path.dirname(__file__), "data.cuh")
-    runner = CliRunner()
-
-    result = runner.invoke(
-        static_binding_generator,
-        [data, "--output-dir", subdir, "--retain", ""],
-    )
-
-    assert result.exit_code == 0, f"CMD ERROR: {result.stdout}"
-
-    output = subdir / "data.py"
-    assert os.path.exists(output)
-
-    with open(output) as f:
-        bindings = f.read()
-
-    globals = {}
-    exec(bindings, globals)
-
-    # Both are not in the retain list
-    assert "Foo" not in globals
-    assert "add" not in globals
-
-
-def test_cli_yml_inputs_full_spec(tmpdir, kernel):
+def test_cli_yml_inputs_full_spec(tmpdir, kernel, arch_str):
     clear_base_renderer_cache()
     clear_function_apis_registry()
 
@@ -158,6 +93,8 @@ def test_cli_yml_inputs_full_spec(tmpdir, kernel):
     cfg = f"""Name: Test Data
 Version: 0.0.1
 Entry Point: {data}
+GPU Arch:
+    - {arch_str}
 File List:
     - {data}
 Exclude: {{}}
@@ -199,7 +136,9 @@ Data Models:
 @pytest.mark.parametrize(
     "cc, expected", [("sm_70", False), ("sm_86", True), ("sm_90", True)]
 )
-def test_cli_yml_inputs_full_spec_with_cc(tmpdir, kernel, cc, expected):
+def test_cli_yml_inputs_full_spec_with_cc(
+    tmpdir, kernel, cc, expected, arch_str
+):
     clear_base_renderer_cache()
     clear_function_apis_registry()
 
@@ -209,6 +148,8 @@ def test_cli_yml_inputs_full_spec_with_cc(tmpdir, kernel, cc, expected):
     cfg = f"""Name: Test Data
 Version: 0.0.1
 Entry Point: {data}
+GPU Arch:
+    - {cc}
 File List:
     - {data}
 Exclude: {{}}
@@ -228,14 +169,12 @@ Data Models:
         [
             "--cfg-path",
             cfg_file,
-            "--compute-capability",
-            cc,
             "--output-dir",
             subdir,
         ],
     )
 
-    assert result.exit_code == 0, f"CMD ERROR: {result.stdout}"
+    assert result.exit_code == 0, f"CMD ERROR: {result.stderr}"
 
     output = subdir / "data.py"
     assert os.path.exists(output)
@@ -249,7 +188,7 @@ Data Models:
     assert ("mul" in bindings) is expected
 
 
-def test_yaml_deduce_missing_types(tmpdir, kernel):
+def test_yaml_deduce_missing_types(tmpdir, kernel, arch_str):
     clear_base_renderer_cache()
     clear_function_apis_registry()
 
@@ -259,6 +198,8 @@ def test_yaml_deduce_missing_types(tmpdir, kernel):
     cfg = f"""Name: Test Data
 Version: 0.0.1
 Entry Point: {data}
+GPU Arch:
+    - {arch_str}
 File List:
     - {data}
 Exclude: {{}}
@@ -282,7 +223,7 @@ Data Models:
         ],
     )
 
-    assert result.exit_code == 0, f"CMD ERROR: {result.stdout}"
+    assert result.exit_code == 0, f"CMD ERROR: {result.stderr}"
 
     output = subdir / "data.py"
     assert os.path.exists(output)
@@ -296,7 +237,7 @@ Data Models:
     kernel(globals)
 
 
-def test_yaml_deduce_missing_datamodels(tmpdir, kernel):
+def test_yaml_deduce_missing_datamodels(tmpdir, kernel, arch_str):
     clear_base_renderer_cache()
     clear_function_apis_registry()
 
@@ -306,6 +247,8 @@ def test_yaml_deduce_missing_datamodels(tmpdir, kernel):
     cfg = f"""Name: Test Data
 Version: 0.0.1
 Entry Point: {data}
+GPU Arch:
+    - {arch_str}
 File List:
     - {data}
 Exclude: {{}}
@@ -330,7 +273,7 @@ Data Models:
         ],
     )
 
-    assert result.exit_code == 0, f"CMD ERROR: {result.stdout}"
+    assert result.exit_code == 0, f"CMD ERROR: {result.stderr}"
 
     output = subdir / "data.py"
     assert os.path.exists(output)
@@ -344,7 +287,7 @@ Data Models:
     kernel(globals)
 
 
-def test_yaml_exclude_function(tmpdir):
+def test_yaml_exclude_function(tmpdir, arch_str):
     clear_base_renderer_cache()
     clear_function_apis_registry()
 
@@ -354,6 +297,8 @@ def test_yaml_exclude_function(tmpdir):
     cfg = f"""Name: Test Data
 Version: 0.0.1
 Entry Point: {data}
+GPU Arch:
+    - {arch_str}
 File List:
     - {data}
 Exclude:
@@ -405,7 +350,7 @@ Data Models:
     assert arr[0] == 0
 
 
-def test_yaml_exclude_function_empty_list(tmpdir, kernel):
+def test_yaml_exclude_function_empty_list(tmpdir, kernel, arch_str):
     clear_base_renderer_cache()
     clear_function_apis_registry()
 
@@ -415,6 +360,8 @@ def test_yaml_exclude_function_empty_list(tmpdir, kernel):
     cfg = f"""Name: Test Data
 Version: 0.0.1
 Entry Point: {data}
+GPU Arch:
+    - {arch_str}
 File List:
     - {data}
 Exclude:
@@ -440,7 +387,7 @@ Data Models:
         ],
     )
 
-    assert result.exit_code == 0, f"CMD ERROR: {result.stdout}"
+    assert result.exit_code == 0, f"CMD ERROR: {result.stderr}"
 
     output = subdir / "data.py"
     assert os.path.exists(output)
@@ -454,7 +401,7 @@ Data Models:
     kernel(globals)
 
 
-def test_yaml_exclude_struct(tmpdir):
+def test_yaml_exclude_struct(tmpdir, arch_str):
     clear_base_renderer_cache()
     clear_function_apis_registry()
 
@@ -464,6 +411,8 @@ def test_yaml_exclude_struct(tmpdir):
     cfg = f"""Name: Test Data
 Version: 0.0.1
 Entry Point: {data}
+GPU Arch:
+    - {arch_str}
 File List:
     - {data}
 Exclude:
@@ -512,7 +461,7 @@ Data Models: {{}}
     assert arr[0] == 3
 
 
-def test_yaml_exclude_struct_empty_list(tmpdir, kernel):
+def test_yaml_exclude_struct_empty_list(tmpdir, kernel, arch_str):
     clear_base_renderer_cache()
     clear_function_apis_registry()
 
@@ -522,6 +471,8 @@ def test_yaml_exclude_struct_empty_list(tmpdir, kernel):
     cfg = f"""Name: Test Data
 Version: 0.0.1
 Entry Point: {data}
+GPU Arch:
+    - {arch_str}
 File List:
     - {data}
 Exclude:
@@ -545,7 +496,7 @@ Data Models: {{}}
         ],
     )
 
-    assert result.exit_code == 0, f"CMD ERROR: {result.stdout}"
+    assert result.exit_code == 0, f"CMD ERROR: {result.stderr}"
 
     output = subdir / "data.py"
     assert os.path.exists(output)

--- a/numbast/src/numbast/tools/tests/test_macros.py
+++ b/numbast/src/numbast/tools/tests/test_macros.py
@@ -32,7 +32,7 @@ def kernel():
     return _lazy_kernel
 
 
-def test_cli_yml_inputs_macro_expansion(tmpdir, kernel):
+def test_cli_yml_inputs_macro_expansion(tmpdir, kernel, arch_str):
     name = "macros"
     subdir = tmpdir.mkdir("sub")
     data = os.path.join(os.path.dirname(__file__), f"{name}.cuh")
@@ -40,6 +40,8 @@ def test_cli_yml_inputs_macro_expansion(tmpdir, kernel):
     cfg = f"""Name: Test Data
 Version: 0.0.1
 Entry Point: {data}
+GPU Arch:
+    - {arch_str}
 File List:
     - {data}
 Macro-expanded Function Prefixes:
@@ -56,8 +58,6 @@ Macro-expanded Function Prefixes:
         [
             "--cfg-path",
             cfg_file,
-            "--compute-capability",
-            "sm_50",
             "--output-dir",
             subdir,
         ],

--- a/numbast/src/numbast/tools/tests/test_module_callbacks.py
+++ b/numbast/src/numbast/tools/tests/test_module_callbacks.py
@@ -6,12 +6,13 @@ import subprocess
 import sys
 
 
-def test_module_callbacks_empty(run_in_isolated_folder):
+def test_module_callbacks_empty(run_in_isolated_folder, arch_str):
     """Test that Module Callbacks work when not provided (empty case)."""
     res = run_in_isolated_folder(
         "module_callbacks.yml.j2",
         "module_callbacks.cuh",
         {
+            "arch_str": arch_str,
             "setup_callback": "",
             "teardown_callback": "",
         },
@@ -70,12 +71,13 @@ kernel[1, 1]()
     )
 
 
-def test_module_callbacks_partial(run_in_isolated_folder):
+def test_module_callbacks_partial(run_in_isolated_folder, arch_str):
     """Test that Module Callbacks work when only one callback is provided."""
     res = run_in_isolated_folder(
         "module_callbacks.yml.j2",
         "module_callbacks.cuh",
         {
+            "arch_str": arch_str,
             "setup_callback": "lambda x: print('Setup only')",
             "teardown_callback": "",
         },
@@ -132,12 +134,13 @@ kernel[1, 1]()
     )
 
 
-def test_module_callbacks_both(run_in_isolated_folder):
+def test_module_callbacks_both(run_in_isolated_folder, arch_str):
     """Test that Module Callbacks work when both setup and teardown are provided."""
     res = run_in_isolated_folder(
         "module_callbacks.yml.j2",
         "module_callbacks.cuh",
         {
+            "arch_str": arch_str,
             "setup_callback": "lambda x: print('Setup callback called')",
             "teardown_callback": "lambda x: print('Teardown callback called')",
         },

--- a/numbast/src/numbast/tools/tests/test_output_name.py
+++ b/numbast/src/numbast/tools/tests/test_output_name.py
@@ -6,7 +6,7 @@ import subprocess
 import sys
 
 
-def test_output_name_override(run_in_isolated_folder):
+def test_output_name_override(run_in_isolated_folder, arch_str):
     """Tests:
     1. Name of output binding can be overridden via `Output Name` entry.
     """
@@ -16,7 +16,7 @@ def test_output_name_override(run_in_isolated_folder):
     res = run_in_isolated_folder(
         "output_name.yml.j2",
         "data.cuh",
-        {},
+        {"arch_str": arch_str},
         output_name=output_name,
         ruff_format=False,
     )

--- a/numbast/src/numbast/tools/tests/test_predefined_macros.py
+++ b/numbast/src/numbast/tools/tests/test_predefined_macros.py
@@ -4,7 +4,7 @@
 from numba import cuda
 
 
-def test_predefined_macros(run_in_isolated_folder):
+def test_predefined_macros(run_in_isolated_folder, arch_str):
     """Consider both the config and output folder are traversible in the same
     tree, this PR makes sure that reproducible info accurately reflect where
     the config file can be located as a relative path to the binding file.
@@ -13,7 +13,7 @@ def test_predefined_macros(run_in_isolated_folder):
     res = run_in_isolated_folder(
         "predefined_macros.yml.j2",
         "predefined_macros.cuh",
-        {},
+        {"arch_str": arch_str},
         ruff_format=True,
         load_symbols=True,
     )

--- a/numbast/src/numbast/tools/tests/test_prefix_removal.py
+++ b/numbast/src/numbast/tools/tests/test_prefix_removal.py
@@ -6,12 +6,12 @@ import subprocess
 import sys
 
 
-def test_prefix_removal(run_in_isolated_folder):
+def test_prefix_removal(run_in_isolated_folder, arch_str):
     """Test that API prefix removal works correctly for function names."""
     res = run_in_isolated_folder(
         "prefix_removal.yml.j2",
         "prefix_removal.cuh",
-        {},
+        {"arch_str": arch_str},
         load_symbols=True,
         ruff_format=False,
     )

--- a/numbast/src/numbast/tools/tests/test_repro_info.py
+++ b/numbast/src/numbast/tools/tests/test_repro_info.py
@@ -2,13 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-def test_repro_info(run_in_isolated_folder):
+def test_repro_info(run_in_isolated_folder, arch_str):
     """Consider both the config and output folder are traversible in the same
     tree, this PR makes sure that reproducible info accurately reflect where
     the config file can be located as a relative path to the binding file.
     """
 
-    res = run_in_isolated_folder("cfg.yml.j2", "data.cuh", {}, ruff_format=True)
+    res = run_in_isolated_folder(
+        "cfg.yml.j2", "data.cuh", {"arch_str": arch_str}, ruff_format=True
+    )
 
     result = res["result"]
     binding_path = res["binding_path"]

--- a/numbast/src/numbast/tools/tests/test_require_pynvjitlink.py
+++ b/numbast/src/numbast/tools/tests/test_require_pynvjitlink.py
@@ -9,14 +9,16 @@ import pytest
 
 
 @pytest.mark.parametrize("require_pynvjitlink", [True, False])
-def test_require_pynvjitlink(run_in_isolated_folder, require_pynvjitlink):
+def test_require_pynvjitlink(
+    run_in_isolated_folder, require_pynvjitlink, arch_str
+):
     """Tests if `require_pynvjitlink` field conditionally adds pynvjitlink
     guard.
     """
     res = run_in_isolated_folder(
         "require_pynvjitlink.yml.j2",
         "data.cuh",
-        {"require_pynvjitlink": require_pynvjitlink},
+        {"require_pynvjitlink": require_pynvjitlink, "arch_str": arch_str},
         ruff_format=False,
     )
 

--- a/numbast/src/numbast/tools/tests/test_shim_include_override.py
+++ b/numbast/src/numbast/tools/tests/test_shim_include_override.py
@@ -6,13 +6,18 @@ import subprocess
 import sys
 
 
-def test_shim_include_override_additional_import(run_in_isolated_folder):
+def test_shim_include_override_additional_import(
+    run_in_isolated_folder, arch_str
+):
     """Tests:
     1. Additional Import field actually adds custom import libs in binding
     2. Shim Include Override overrides the shim include line
     """
     res = run_in_isolated_folder(
-        "shim_include_override.yml.j2", "data.cuh", {}, ruff_format=False
+        "shim_include_override.yml.j2",
+        "data.cuh",
+        {"arch_str": arch_str},
+        ruff_format=False,
     )
 
     run_result = res["result"]

--- a/numbast/src/numbast/tools/tests/test_symbol_exposure.py
+++ b/numbast/src/numbast/tools/tests/test_symbol_exposure.py
@@ -11,10 +11,14 @@ dev = Device(0)
 cc = dev.compute_capability
 
 
-def test_symbol_exposure(run_in_isolated_folder):
+def test_symbol_exposure(run_in_isolated_folder, arch_str):
     """Test that only a limited set of symbols are exposed via __all__ imports."""
     res = run_in_isolated_folder(
-        "cfg.yml.j2", "data.cuh", {}, load_symbols=True, ruff_format=False
+        "cfg.yml.j2",
+        "data.cuh",
+        {"arch_str": arch_str},
+        load_symbols=True,
+        ruff_format=False,
     )
 
     run_result = res["result"]

--- a/numbast/src/numbast/tools/tests/test_use_cooperative.py
+++ b/numbast/src/numbast/tools/tests/test_use_cooperative.py
@@ -8,12 +8,12 @@ import sys
 import pytest
 
 
-def test_use_cooperative(run_in_isolated_folder):
+def test_use_cooperative(run_in_isolated_folder, arch_str):
     """Test that only a limited set of symbols are exposed via __all__ imports."""
     res = run_in_isolated_folder(
         "cooperative_launch.yml.j2",
         "use_cooperative.cuh",
-        {},
+        {"arch_str": arch_str},
         load_symbols=True,
         ruff_format=False,
     )
@@ -48,12 +48,12 @@ assert kernel.overloads[()].cooperative, f"{{kernel.overloads[()].cooperative=}}
     assert res.returncode == 0, res.stdout.decode("utf-8")
 
 
-def test_use_cooperative_regex_patterns(run_in_isolated_folder):
+def test_use_cooperative_regex_patterns(run_in_isolated_folder, arch_str):
     """Test that regex patterns correctly match function names for cooperative launch."""
     res = run_in_isolated_folder(
         "cooperative_launch_regex.yml.j2",
         "use_cooperative.cuh",
-        {},
+        {"arch_str": arch_str},
         load_symbols=True,
         ruff_format=False,
     )
@@ -132,12 +132,14 @@ assert block_sync_kernel.overloads[()].cooperative, f"block_sync_threads should 
     assert res.returncode == 0, res.stdout.decode("utf-8")
 
 
-def test_use_cooperative_non_matching_functions(run_in_isolated_folder):
+def test_use_cooperative_non_matching_functions(
+    run_in_isolated_folder, arch_str
+):
     """Test that functions not matching regex patterns are not marked as cooperative."""
     res = run_in_isolated_folder(
         "cooperative_launch_regex.yml.j2",
         "use_cooperative.cuh",
-        {},
+        {"arch_str": arch_str},
         load_symbols=True,
         ruff_format=False,
     )
@@ -176,14 +178,14 @@ assert not regular_kernel.overloads[()].cooperative, f"regular_function should n
     assert res.returncode == 0, res.stdout.decode("utf-8")
 
 
-def test_use_cooperative_invalid_regex(run_in_isolated_folder):
+def test_use_cooperative_invalid_regex(run_in_isolated_folder, arch_str):
     """Test that functions not matching regex patterns are not marked as cooperative."""
 
     with pytest.raises(ValueError, match="Invalid regex pattern"):
         run_in_isolated_folder(
             "cooperative_launch_invalid_regex.yml.j2",
             "use_cooperative.cuh",
-            {},
+            {"arch_str": arch_str},
             load_symbols=True,
             ruff_format=False,
         )


### PR DESCRIPTION
This PR adds `GPU Arch` entry in the yaml config file to specify the CC to generate for strings. Note that currently we only support generating for a single GPU arch, though multiple targets are meant to be a future PR.