### PR TITLE
Allow creation of custom typing/target registry

### DIFF
--- a/numbast/src/numbast/static/function.py
+++ b/numbast/src/numbast/static/function.py
@@ -273,7 +273,6 @@ def {func_name}():
     def _render_lowering(self):
         """Render lowering codes for this struct constructor."""
 
-        self.Imports.add("from numba.cuda.cudaimpl import lower")
         self.Imports.add("from numba.core.typing import signature")
 
         use_cooperative = ""
@@ -615,8 +614,6 @@ class {op_typing_name}(ConcreteTemplate):
 
     def _render_typings(self):
         """Render typing for all functions"""
-        self.Imports.add("from numba.cuda.cudadecl import register")
-        self.Imports.add("from numba.cuda.cudadecl import register_global")
         self.Imports.add("from numba import types")
         self.Imports.add(
             "from numba.core.typing.templates import ConcreteTemplate"

--- a/numbast/src/numbast/static/renderer.py
+++ b/numbast/src/numbast/static/renderer.py
@@ -21,6 +21,17 @@ if not importlib.util.find_spec("pynvjitlink"):
     raise RuntimeError("Pynvjitlink is required to run this binding.")
 """
 
+    SeparateRegistrySetup = """
+typing_registry = TypingRegistry()
+register = typing_registry.register
+register_attr = typing_registry.register_attr
+register_global = typing_registry.register_global
+target_registry = TargetRegistry()
+lower = target_registry.lower
+lower_attr = target_registry.lower_getattr
+lower_constant = target_registry.lower_constant
+"""
+
     KeyedStringIO = """
 class _KeyedStringIO(io.StringIO):
     def __init__(self, *arg, **kwarg):
@@ -272,3 +283,36 @@ __all__ = _NBTYPE_SYMBOLS + _RECORD_SYMBOLS + _FUNCTION_SYMBOLS
 """
 
     return all_symbols
+
+
+def registry_setup(use_separate_registry: bool) -> str:
+    """Get the registry setup code.
+
+    In Numba-CUDA, builtin registries are created a cudadecl and cudaimpl.
+    By default, Numbast bindings inject the registries into the existing
+    typing and target context. When use_separate_registry is True, Numbast
+    bindings create a new typing and target registry. User should add the
+    registries to the typing and target context manually.
+    """
+    if use_separate_registry:
+        BaseRenderer.Imports.add(
+            "from numba.core.typing.templates import Registry as TypingRegistry"
+        )
+        BaseRenderer.Imports.add(
+            "from numba.core.imputils import Registry as TargetRegistry"
+        )
+        return BaseRenderer.SeparateRegistrySetup
+    else:
+        BaseRenderer.Imports.add("from numba.cuda.cudadecl import register")
+        BaseRenderer.Imports.add(
+            "from numba.cuda.cudadecl import register_global"
+        )
+        BaseRenderer.Imports.add(
+            "from numba.cuda.cudadecl import register_attr"
+        )
+        BaseRenderer.Imports.add("from numba.cuda.cudaimpl import lower")
+        BaseRenderer.Imports.add("from numba.cuda.cudaimpl import lower_attr")
+        BaseRenderer.Imports.add(
+            "from numba.cuda.cudaimpl import lower_constant"
+        )
+        return ""

--- a/numbast/src/numbast/static/struct.py
+++ b/numbast/src/numbast/static/struct.py
@@ -234,8 +234,6 @@ def {lower_scope_name}(shim_stream, shim_obj):
     def _render_lowering(self):
         """Render lowering codes for this struct constructor."""
 
-        self.Imports.add("from numba.cuda.cudaimpl import lower")
-
         self._lowering_rendered = self.struct_ctor_lowering_template.format(
             struct_name=self._struct_name,
             param_types=self._nb_param_types_str,
@@ -337,8 +335,6 @@ register_global({struct_name}, Function({struct_ctor_template_name}))
             the constructors.
         """
 
-        self.Imports.add("from numba.cuda.cudadecl import register")
-        self.Imports.add("from numba.cuda.cudadecl import register_global")
         self.Imports.add(
             "from numba.core.typing.templates import ConcreteTemplate"
         )
@@ -828,7 +824,6 @@ class {struct_attr_typing_name}(AttributeTemplate):
         self._struct_attr_typing_rendered = ""
 
         if self._data_model == StructModel:
-            self.Imports.add("from numba.cuda.cudadecl import register_attr")
             self.Imports.add(
                 "from numba.core.typing.templates import AttributeTemplate"
             )

--- a/numbast/src/numbast/static/tests/conftest.py
+++ b/numbast/src/numbast/static/tests/conftest.py
@@ -7,6 +7,7 @@ import os
 from typing import Any
 
 from numbast.static.renderer import clear_base_renderer_cache
+from numbast.static.function import clear_function_apis_registry
 from numbast.tools.static_binding_generator import (
     _static_binding_generator,
     Config,
@@ -29,6 +30,8 @@ def make_binding(tmpdir, data_folder):
         cc: str = "sm_80",
     ):
         clear_base_renderer_cache()
+        clear_function_apis_registry()
+
         header_path = data_folder(header_name)
         cfg = Config.from_params(
             entry_point=header_path,
@@ -36,6 +39,7 @@ def make_binding(tmpdir, data_folder):
             gpu_arch=[cc],
             types=types,
             datamodels=datamodels,
+            separate_registry=False,
         )
         _static_binding_generator(cfg, tmpdir)
 

--- a/numbast/src/numbast/static/tests/test_enum_static_bindings.py
+++ b/numbast/src/numbast/static/tests/test_enum_static_bindings.py
@@ -5,13 +5,15 @@ import pytest
 
 
 from ast_canopy import parse_declarations_from_source
-from numbast.static.renderer import clear_base_renderer_cache
+from numbast.static.renderer import clear_base_renderer_cache, registry_setup
+from numbast.static.function import clear_function_apis_registry
 from numbast.static.enum import StaticEnumsRenderer
 
 
 @pytest.fixture(scope="module")
 def cuda_enum(data_folder):
     clear_base_renderer_cache()
+    clear_function_apis_registry()
 
     header = data_folder("enum.cuh")
 
@@ -20,6 +22,7 @@ def cuda_enum(data_folder):
 
     assert len(enums) == 2
 
+    registry_setup(use_separate_registry=False)
     SER = StaticEnumsRenderer(enums)
 
     bindings = SER.render_as_str(

--- a/numbast/src/numbast/static/tests/test_function_static_bindings.py
+++ b/numbast/src/numbast/static/tests/test_function_static_bindings.py
@@ -12,7 +12,7 @@ from numba.cuda import device_array
 
 from ast_canopy import parse_declarations_from_source
 
-from numbast.static.renderer import clear_base_renderer_cache
+from numbast.static.renderer import clear_base_renderer_cache, registry_setup
 from numbast.static.function import (
     StaticFunctionsRenderer,
     clear_function_apis_registry,
@@ -31,6 +31,7 @@ def decl(data_folder):
 
     assert len(functions) == 5
 
+    registry_setup(use_separate_registry=False)
     SFR = StaticFunctionsRenderer(functions, header)
 
     bindings = SFR.render_as_str(

--- a/numbast/src/numbast/static/tests/test_link_two_files.py
+++ b/numbast/src/numbast/static/tests/test_link_two_files.py
@@ -8,7 +8,7 @@ from numba.types import Type, Number
 from numba.core.datamodel import StructModel, PrimitiveModel
 
 from ast_canopy import parse_declarations_from_source
-from numbast.static.renderer import clear_base_renderer_cache
+from numbast.static.renderer import clear_base_renderer_cache, registry_setup
 from numbast.static.struct import StaticStructsRenderer
 from numbast.static.function import (
     StaticFunctionsRenderer,
@@ -42,6 +42,7 @@ def foo_decl(header):
 
     assert len(structs) == 3
 
+    registry_setup(use_separate_registry=False)
     SSR = StaticStructsRenderer(structs, specs, header)
 
     bindings = SSR.render_as_str(
@@ -69,6 +70,7 @@ def function_decl(header):
 
     assert len(functions) == 5
 
+    registry_setup(use_separate_registry=False)
     SFR = StaticFunctionsRenderer(functions, header)
 
     bindings = SFR.render_as_str(

--- a/numbast/src/numbast/static/tests/test_operator_bindings.py
+++ b/numbast/src/numbast/static/tests/test_operator_bindings.py
@@ -14,8 +14,10 @@ from numbast.static.renderer import (
     get_rendered_imports,
     get_shim,
     get_pynvjitlink_guard,
+    registry_setup,
 )
 from numbast.static.renderer import clear_base_renderer_cache
+from numbast.static.function import clear_function_apis_registry
 from numbast.static.struct import StaticStructsRenderer
 from numbast.static.function import StaticFunctionsRenderer
 
@@ -23,6 +25,7 @@ from numbast.static.function import StaticFunctionsRenderer
 @pytest.fixture(scope="module")
 def cuda_decls(data_folder):
     clear_base_renderer_cache()
+    clear_function_apis_registry()
 
     header = data_folder("operator.cuh")
 
@@ -34,6 +37,7 @@ def cuda_decls(data_folder):
 
     assert len(structs) == 1
 
+    registry_setup(use_separate_registry=False)
     SSR = StaticStructsRenderer(structs, specs)
     SFR = StaticFunctionsRenderer(functions, header)
 

--- a/numbast/src/numbast/static/tests/test_static_demo.py
+++ b/numbast/src/numbast/static/tests/test_static_demo.py
@@ -10,10 +10,15 @@ from numba.cuda import device_array
 
 from ast_canopy import parse_declarations_from_source
 from numbast.static.struct import StaticStructsRenderer
+from numbast.static.renderer import clear_base_renderer_cache, registry_setup
+from numbast.static.function import clear_function_apis_registry
 
 
 @pytest.fixture(scope="module")
 def decl(data_folder):
+    clear_base_renderer_cache()
+    clear_function_apis_registry()
+
     header = data_folder("demo.cuh")
 
     specs = {"__myfloat16": (Number, PrimitiveModel, header)}
@@ -23,6 +28,7 @@ def decl(data_folder):
 
     assert len(structs) == 1
 
+    registry_setup(use_separate_registry=False)
     SSR = StaticStructsRenderer(structs, specs, header)
 
     bindings = SSR.render_as_str(

--- a/numbast/src/numbast/static/tests/test_struct_static_bindings.py
+++ b/numbast/src/numbast/static/tests/test_struct_static_bindings.py
@@ -9,7 +9,8 @@ from numba.core.datamodel import StructModel, PrimitiveModel
 from numba.cuda import device_array
 
 from ast_canopy import parse_declarations_from_source
-from numbast.static.renderer import clear_base_renderer_cache
+from numbast.static.renderer import clear_base_renderer_cache, registry_setup
+from numbast.static.function import clear_function_apis_registry
 from numbast.static.struct import StaticStructsRenderer
 
 
@@ -21,7 +22,7 @@ def header(data_folder):
 @pytest.fixture(scope="module")
 def decl(data_folder, header):
     clear_base_renderer_cache()
-
+    clear_function_apis_registry()
     specs = {
         "Foo": (Type, StructModel, header),
         "Bar": (Type, StructModel, header),
@@ -33,6 +34,7 @@ def decl(data_folder, header):
 
     assert len(structs) == 3
 
+    registry_setup(use_separate_registry=False)
     SSR = StaticStructsRenderer(structs, specs, header)
 
     bindings = SSR.render_as_str(

--- a/numbast/src/numbast/tools/static_binding_generator.py
+++ b/numbast/src/numbast/tools/static_binding_generator.py
@@ -29,6 +29,7 @@ from numbast.static.renderer import (
     get_rendered_imports,
     get_reproducible_info,
     get_all_exposed_symbols,
+    registry_setup,
 )
 from numbast.static.struct import StaticStructsRenderer
 from numbast.static.function import (
@@ -104,6 +105,11 @@ class Config:
     skip_prefix : str | None
         Do not generate bindings for any functions that start with this prefix.
         Has no effect if left unspecified.
+    separate_registry : bool
+        If true, use a separate typing and target registry for the generated binding.
+        By default, the new typing and target registries are added to the existing
+        typing and target context. When set to true, user should add the registries
+        to the typing and target context manually. Default to False.
     """
 
     entry_point: str
@@ -124,6 +130,7 @@ class Config:
     api_prefix_removal: dict[str, list[str]]
     module_callbacks: dict[str, str]
     skip_prefix: str | None
+    separate_registry: bool
 
     def __init__(self, config_dict: dict):
         """Initialize Config from a dictionary.
@@ -187,6 +194,8 @@ class Config:
         self.module_callbacks = config_dict.get("Module Callbacks", {})
         self.skip_prefix = config_dict.get("Skip Prefix", None)
 
+        self.separate_registry = config_dict.get("Use Separate Registry", False)
+
         # TODO: support multiple GPU architectures
         if len(self.gpu_arch) > 1:
             raise NotImplementedError(
@@ -235,6 +244,7 @@ class Config:
         api_prefix_removal: dict[str, list[str]] | None = None,
         module_callbacks: dict[str, str] | None = None,
         skip_prefix: str | None = None,
+        separate_registry: bool = False,
     ) -> "Config":
         """Create a Config instance from individual parameters instead of a config file."""
         if types is None:
@@ -265,6 +275,7 @@ class Config:
             "API Prefix Removal": api_prefix_removal or {},
             "Module Callbacks": module_callbacks or {},
             "Skip Prefix": skip_prefix,
+            "Separate Registry": separate_registry,
         }
 
         # Convert types and datamodels back to string format for the dict
@@ -551,6 +562,8 @@ def _static_binding_generator(
     else:
         pynvjitlink_guard = ""
 
+    registry_setup_str = registry_setup(config.separate_registry)
+
     if config.shim_include_override is not None:
         shim_include = f"'#include <' + {config.shim_include_override} + '>'"
     else:
@@ -590,6 +603,7 @@ def _static_binding_generator(
 {imports_str}
 # Setups:
 {pynvjitlink_guard}
+{registry_setup_str}
 # Shim Stream:
 {shim_stream_str}
 # Enums:

--- a/numbast/src/numbast/tools/tests/config/use_separate_registry.yml.j2
+++ b/numbast/src/numbast/tools/tests/config/use_separate_registry.yml.j2
@@ -1,0 +1,13 @@
+Name: Test Data
+Version: 0.0.1
+Entry Point: {{ data }}
+GPU Arch:
+    - {{ arch_str }}
+File List:
+    - {{ data }}
+Exclude: {}
+Types:
+    Foo: Type
+Data Models:
+    Foo: StructModel
+Use Separate Registry: {{ use_separate_registry }}

--- a/numbast/src/numbast/tools/tests/test_use_separate_registry.py
+++ b/numbast/src/numbast/tools/tests/test_use_separate_registry.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+
+import pytest
+
+
+@pytest.mark.parametrize("use_separate_registry", [True, False])
+def test_use_separate_registry(
+    run_in_isolated_folder, arch_str, use_separate_registry
+):
+    """Test when use_separate_registry is set, the geneerated binding will create or reuse registries accordingly."""
+    res = run_in_isolated_folder(
+        "use_separate_registry.yml.j2",
+        "data.cuh",
+        {"arch_str": arch_str, "use_separate_registry": use_separate_registry},
+        ruff_format=False,
+    )
+
+    run_result = res["result"]
+    assert run_result.exit_code == 0
+
+    binding = res["binding"]
+
+    if use_separate_registry:
+        assert "TypingRegistry" in binding
+        assert "TargetRegistry" in binding
+    else:
+        assert "TypingRegistry" not in binding
+        assert "TargetRegistry" not in binding


### PR DESCRIPTION
In Numba-CUDA's fp16 bindings, we have separate introduction of typing and target registries. This PR automates that within the Numbast pipeline with `Use Separate Registries` entry to control that.
