### PR TITLE
remove dependency on RAPIDS conda channels

### DIFF
--- a/ci/build_conda_python.sh
+++ b/ci/build_conda_python.sh
@@ -4,8 +4,6 @@
 
 set -euo pipefail
 
-rapids-configure-conda-channels
-
 source rapids-configure-sccache
 
 source rapids-date-string

--- a/conda/environment.yaml
+++ b/conda/environment.yaml
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 name: numbast
 channels:
-  - rapidsai
-  - rapidsai-nightly
   - numba
   - conda-forge
   - nvidia

--- a/conda/environment_template.yaml
+++ b/conda/environment_template.yaml
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 name: numbast
 channels:
-  - rapidsai
-  - rapidsai-nightly
   - numba
   - conda-forge
   - nvidia


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/gha-tools/issues/145

Similar to https://github.com/NVIDIA/numba-cuda/pull/372

Now that this project does not rely on `pynvjitlink` (#159), it doesn't need any configuration related to the `rapids` or `rapidsai-nightly` conda channels.

This proposes removing such configuration.