### PR TITLE
Handle unnamed parameters in generated CUDA shims

### DIFF
--- a/numbast/src/numbast/static/struct.py
+++ b/numbast/src/numbast/static/struct.py
@@ -23,6 +23,7 @@ from numbast.utils import (
     deduplicate_overloads,
     make_struct_ctor_shim,
     make_struct_conversion_operator_shim,
+    sanitize_param_names,
 )
 from numbast.errors import TypeNotFoundError
 
@@ -173,10 +174,12 @@ def {lower_scope_name}(shim_stream, shim_obj):
             _pointer_wrapped_param_types
         )
 
+        self._param_names = sanitize_param_names(self._ctor_decl.params)
+
         # Cache the list of parameter types in C++ pointer types
         c_ptr_arglist = ", ".join(
-            f"{arg.type_.unqualified_non_ref_type_name}* {arg.name}"
-            for arg in self._ctor_decl.params
+            f"{arg.type_.unqualified_non_ref_type_name}* {name}"
+            for name, arg in zip(self._param_names, self._ctor_decl.params)
         )
         if c_ptr_arglist:
             c_ptr_arglist = ", " + c_ptr_arglist
@@ -185,7 +188,7 @@ def {lower_scope_name}(shim_stream, shim_obj):
 
         # Cache the list of dereferenced arguments
         self._deref_args_str = ", ".join(
-            "*" + arg.name for arg in self._ctor_decl.params
+            "*" + name for name in self._param_names
         )
 
         # Cache the unique shim name

--- a/numbast/tests/test_utils.py
+++ b/numbast/tests/test_utils.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from numbast.utils import make_function_shim
+
+
+class _DummyType:
+    def __init__(self, name: str):
+        self.unqualified_non_ref_type_name = name
+
+
+class _DummyParam:
+    def __init__(self, type_name: str, name: str = ""):
+        self.type_ = _DummyType(type_name)
+        self.name = name
+        self.unqualified_non_ref_type_name = type_name
+
+
+def test_make_function_shim_names_unnamed_parameters():
+    params = [_DummyParam("Foo", "")]
+
+    shim = make_function_shim("shim", "useFoo", "bool", params)
+
+    assert "Foo* arg0" in shim
+    assert "useFoo(*arg0);" in shim
+
+
+def test_make_function_shim_disambiguates_duplicate_names():
+    params = [_DummyParam("Foo", "x"), _DummyParam("Bar", "x")]
+
+    shim = make_function_shim("shim", "useFoo", "bool", params)
+
+    assert "Foo* x" in shim
+    # The second argument should be suffixed to avoid clashing with the first.
+    assert "Bar* x_1" in shim
+    assert "useFoo(*x, *x_1);" in shim


### PR DESCRIPTION
## Summary
- generate stable fallback identifiers for unnamed function parameters when building CUDA shims
- reuse the sanitized names across dynamic/static bindings so call sites emit valid C++
- cover the regression with unit tests that exercise shim generation

## Rationale
- fixes NVIDIA/numbast#168 where unnamed C++ parameters were emitted as  in shims, leading NVRTC to fail with 

## Changes
- add a shared sanitizer for C++ parameter names and apply it across function/struct binding code
- ensure shim generators dereference the sanitized identifiers instead of the raw (possibly empty) names
- new tests validating that unnamed and duplicate parameters render distinct argument names
- Tests not run (pytest)

Fixes #168