### PR TITLE
Propagate CMAKE_PREFIX_PATH from environment variable properly to skbuild

### DIFF
--- a/ast_canopy/CMakeLists.txt
+++ b/ast_canopy/CMakeLists.txt
@@ -11,8 +11,6 @@ project(${SKBUILD_PROJECT_NAME}
 	LANGUAGES C CXX)
 
 
-set(CMAKE_FIND_DEBUG_MODE ON)
-
 find_package(Python REQUIRED COMPONENTS Interpreter Development.Module)
 find_package(pybind11 CONFIG REQUIRED)
 find_package(astcanopy ${SKBUILD_PROJECT_VERSION} REQUIRED)

--- a/ast_canopy/CMakeLists.txt
+++ b/ast_canopy/CMakeLists.txt
@@ -10,6 +10,9 @@ project(${SKBUILD_PROJECT_NAME}
         VERSION ${SKBUILD_PROJECT_VERSION}
 	LANGUAGES C CXX)
 
+
+set(CMAKE_FIND_DEBUG_MODE ON)
+
 find_package(Python REQUIRED COMPONENTS Interpreter Development.Module)
 find_package(pybind11 CONFIG REQUIRED)
 find_package(astcanopy ${SKBUILD_PROJECT_VERSION} REQUIRED)

--- a/ast_canopy/build.sh
+++ b/ast_canopy/build.sh
@@ -115,12 +115,9 @@ echo ""
 # Determine base CMAKE_PREFIX_PATH and default CMAKE_INSTALL_PREFIX
 # FIXME: We currently rely on environment CMAKE_PREFIX_PATH, which is often
 #        colon-delimited like PATH. CMake expects semicolons. We only
-#        normalize when passing it as a CMake option below; revisit this
-#        behavior to avoid delimiter confusion in the environment.
+#        normalize when passing it as a CMake option below; really, we should
+#        always use colon-delimited paths in the environment.
 if [ -n "$CMAKE_PREFIX_PATH" ]; then
-    # If the environment variable was set with semicolons (CMake-style),
-    # normalize it back to colons for environment semantics.
-
     echo "Using CMAKE_PREFIX_PATH from environment: $CMAKE_PREFIX_PATH"
 fi
 
@@ -149,6 +146,8 @@ if [ -n "$ASTCANOPY_INSTALL_PATH" ]; then
     fi
 fi
 
+# If the environment variable was set with semicolons (CMake-style),
+# normalize it back to colons for environment semantics.
 if [[ "$CMAKE_PREFIX_PATH" == *";"* ]]; then
     # FIXME: Environment CMAKE_PREFIX_PATH should be colon-delimited; normalizing.
     export CMAKE_PREFIX_PATH="$(normalize_env_prefix_path "$CMAKE_PREFIX_PATH")"

--- a/ast_canopy/build.sh
+++ b/ast_canopy/build.sh
@@ -120,10 +120,7 @@ echo ""
 if [ -n "$CMAKE_PREFIX_PATH" ]; then
     # If the environment variable was set with semicolons (CMake-style),
     # normalize it back to colons for environment semantics.
-    if [[ "$CMAKE_PREFIX_PATH" == *";"* ]]; then
-        # FIXME: Environment CMAKE_PREFIX_PATH should be colon-delimited; normalizing.
-        export CMAKE_PREFIX_PATH="$(normalize_env_prefix_path "$CMAKE_PREFIX_PATH")"
-    fi
+
     echo "Using CMAKE_PREFIX_PATH from environment: $CMAKE_PREFIX_PATH"
 fi
 
@@ -150,6 +147,11 @@ if [ -n "$ASTCANOPY_INSTALL_PATH" ]; then
     else
         export CMAKE_PREFIX_PATH="${ASTCANOPY_INSTALL_PATH}"
     fi
+fi
+
+if [[ "$CMAKE_PREFIX_PATH" == *";"* ]]; then
+    # FIXME: Environment CMAKE_PREFIX_PATH should be colon-delimited; normalizing.
+    export CMAKE_PREFIX_PATH="$(normalize_env_prefix_path "$CMAKE_PREFIX_PATH")"
 fi
 
 echo "CMAKE_PREFIX_PATH: ${CMAKE_PREFIX_PATH}"

--- a/ast_canopy/build.sh
+++ b/ast_canopy/build.sh
@@ -25,6 +25,17 @@ normalize_cmake_prefix_path() {
     fi
 }
 
+# Convert a semicolon-separated path list (CMake style) into a
+# colon-separated list (environment style)
+normalize_env_prefix_path() {
+    local input="$1"
+    if [[ -z "$input" ]]; then
+        echo ""
+    else
+        echo "${input//;/:}"
+    fi
+}
+
 usage() {
     echo "Usage: ./build.sh [options]"
     echo ""
@@ -107,6 +118,12 @@ echo ""
 #        normalize when passing it as a CMake option below; revisit this
 #        behavior to avoid delimiter confusion in the environment.
 if [ -n "$CMAKE_PREFIX_PATH" ]; then
+    # If the environment variable was set with semicolons (CMake-style),
+    # normalize it back to colons for environment semantics.
+    if [[ "$CMAKE_PREFIX_PATH" == *";"* ]]; then
+        # FIXME: Environment CMAKE_PREFIX_PATH should be colon-delimited; normalizing.
+        export CMAKE_PREFIX_PATH="$(normalize_env_prefix_path "$CMAKE_PREFIX_PATH")"
+    fi
     echo "Using CMAKE_PREFIX_PATH from environment: $CMAKE_PREFIX_PATH"
 fi
 


### PR DESCRIPTION
In https://github.com/NVIDIA/numbast/pull/188 `build.sh` we captured `CMAKE_PREFIX_PATH` *from environment* and pass it to astcanopy build options. The argument specified in the docstring says that it is a "semicolon separated list". This contradicts with cmake standard where environment variable are "colon separated list", while cmake options arguments are "semicolon separated list". Additionally `ASTCANOPY_INSTALL_PATH` is concatenated to `CMAKE_PREFIX_PATH` with semi-colon delimiter, further violating the convention.

This caused a bug where the downstream skbuild for pylibastcanopy picked up the wrongly delimited list and failed to search the install path of astcanopy.

This PR is a temporary fix for this issue. It implements two normalizer, and uniformly converts the list into:
- colon separated list for environment variables
- semicolon separated list for cmake arguments

However, ideally we should rely on cmake loading the variables from environment and not try to pass it via argument (we are not doing any fancy parsing of the path list anyway).