### PR TITLE
Add CI Scripts to Build Documentation Pages to GH-Pages

### DIFF
--- a/.github/actions/docs-build/action.yml
+++ b/.github/actions/docs-build/action.yml
@@ -1,0 +1,47 @@
+name: "Numbast Docs Build/Upload"
+description: "Builds the Numbast docs and uploads them as workflow artifacts."
+inputs:
+  upload_workflow_artifact:
+    description: "Uploads the built docs as a workflow artifact (actions/upload-artifact)."
+    required: false
+    default: "true"
+runs:
+  using: "composite"
+  steps:
+    # Install required dependencies
+    - name: Install docs build dependencies
+      shell: bash --noprofile --norc -euo pipefail {0}
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y cmake ninja-build python3-venv git flex bison
+    # Setup Python and install Python deps needed for Sphinx build
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+    - name: Install Python dependencies for docs
+      shell: bash --noprofile --norc -euo pipefail {0}
+      run: |
+        python -m pip install --upgrade pip
+        # Install Numbast and docs dependencies
+        python -m pip install .
+        python -m pip install sphinx nvidia-sphinx-theme sphinx-copybutton
+    # Build all docs
+    - name: Build all docs
+      shell: bash --noprofile --norc -euo pipefail {0}
+      run: ci/build_docs.sh
+    # Copy all docs to the right folder
+    - name: Move docs to right folder
+      shell: bash --noprofile --norc -euo pipefail {0}
+      run: |
+        mkdir -p _site
+        cp -rf ./docs/build/html/* _site/
+        touch _site/.nojekyll
+    # Update docs as workflow artifact:
+    - name: Upload artifact
+      if: ${{ inputs.upload_workflow_artifact == 'true' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: docs
+        path: _site/
+        compression-level: 0

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,0 +1,115 @@
+name: Deploy Numbast Documentation
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+  # Reusable workflow for PR previews
+  workflow_call:
+    inputs:
+      destination_dir:
+        description: "Destination directory for deployment"
+        required: false
+        default: "docs"
+        type: string
+      pr_number:
+        description: "PR number for preview URL generation"
+        required: false
+        default: ""
+        type: string
+      remove_pr_preview:
+        description: "If true, deploy empty folder to remove PR preview"
+        required: false
+        default: false
+        type: boolean
+    outputs:
+      preview_url:
+        description: "The URL where the PR preview is deployed"
+        value: ${{ jobs.build-and-deploy.outputs.preview_url }}
+# Sets permissions of the GITHUB_TOKEN to allow GitHub Pages deployment and PR comments
+permissions:
+  contents: write
+  pull-requests: write
+  pages: write
+# Serialize deploy/cleanup for same PR to prevent races
+concurrency:
+  group: ${{ inputs.pr_number && format('pr-preview-{0}', inputs.pr_number) || 'pages-main' }}
+  cancel-in-progress: false
+jobs:
+  # Build and deploy job
+  build-and-deploy:
+    runs-on: ${{ github.repository == 'NVIDIA/numbast' && 'linux-amd64-cpu32' || 'ubuntu-latest' }}
+    outputs:
+      preview_url: ${{ steps.set-preview-url.outputs.preview_url }}
+    steps:
+      - name: Validate inputs
+        run: |
+          if [ "${{ inputs.remove_pr_preview }}" = "true" ] && [ -z "${{ inputs.pr_number }}" ]; then
+            echo "Error: remove_pr_preview requires pr_number to be set"
+            exit 1
+          fi
+          if [ -n "${{ inputs.pr_number }}" ] && ! echo "${{ inputs.pr_number }}" | grep -qE '^[0-9]+$'; then
+            echo "Error: pr_number must be numeric (got: '${{ inputs.pr_number }}')"
+            exit 1
+          fi
+      - name: Set preview URL
+        id: set-preview-url
+        run: |
+          if [ -n "${{ inputs.pr_number }}" ]; then
+            echo "preview_url=https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/pr-preview/pr-${{ inputs.pr_number }}/" >> $GITHUB_OUTPUT
+          else
+            echo "preview_url=" >> $GITHUB_OUTPUT
+          fi
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Build docs
+        if: ${{ !inputs.remove_pr_preview }}
+        uses: ./.github/actions/docs-build
+        with:
+          upload_workflow_artifact: "true"
+      - name: Create empty directory for cleanup
+        if: ${{ inputs.remove_pr_preview }}
+        run: |
+          mkdir -p _site
+          echo "# Preview Removed" > _site/README.md
+          echo "This PR preview has been removed because the pull request was closed." >> _site/README.md
+      - name: Set commit message
+        id: commit-msg
+        run: |
+          if [ "${{ inputs.remove_pr_preview }}" = "true" ]; then
+            echo "message=Clean up doc preview for PR ${{ inputs.pr_number }} (${{ github.sha }})" >> $GITHUB_OUTPUT
+          elif [ -n "${{ inputs.pr_number }}" ]; then
+            echo "message=Deploy doc preview for PR ${{ inputs.pr_number }} (${{ github.sha }})" >> $GITHUB_OUTPUT
+          else
+            echo "message=Deploy main docs (${{ github.sha }})" >> $GITHUB_OUTPUT
+          fi
+      - name: Deploy .nojekyll to docs root
+        if: ${{ github.event_name == 'push' && !inputs.pr_number }} # Only create .nojekyll for main docs deployment
+        run: |
+          mkdir -p _nojekyll
+          touch _nojekyll/.nojekyll
+      - name: Ensure Jekyll is disabled for GitHub Pages
+        if: ${{ github.event_name == 'push' && !inputs.pr_number }} # Only deploy .nojekyll for main docs, not PR previews
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./_nojekyll
+          publish_branch: gh-pages
+          destination_dir: docs
+          keep_files: true
+          commit_message: "Deploy .nojekyll to disable Jekyll processing"
+      - name: Deploy to GitHub Pages
+        if: ${{ github.event_name == 'push' && !inputs.pr_number }} # Don't deploy doc previews for now to avoid overflowing gh-pages branch
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./_site
+          publish_branch: gh-pages
+          destination_dir: ${{ inputs.destination_dir || 'docs' }}
+          keep_files: true
+          commit_message: ${{ steps.commit-msg.outputs.message }}
+
+# PR comment steps omitted for now to match CCCL template

--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Delegate to the project docs build script. Accept optional "latest-only" arg.
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT="${SCRIPT_DIR}/.."
+
+pushd "${REPO_ROOT}/docs" >/dev/null
+./build_docs.sh "${1:-}"
+popd >/dev/null


### PR DESCRIPTION
This mimics the CCCL github pages. On every merge to `main`, the docs are rebuilt and pushed to gh-pages branch. 

PR-preview pages are not setup, matching the status quo.