### PR TITLE
use readme.md as PYPI description readme

### DIFF
--- a/ast_canopy/pyproject.toml
+++ b/ast_canopy/pyproject.toml
@@ -8,6 +8,7 @@ build-backend = "scikit_build_core.build"
 [project]
 name = "ast_canopy"
 dynamic = ["version"]
+readme = { file = "README.md", content-type = "text/markdown" }
 
 [tool.scikit-build]
 cmake.targets = ["pylibastcanopy"]

--- a/numbast/pyproject.toml
+++ b/numbast/pyproject.toml
@@ -8,6 +8,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "numbast"
 dynamic = ["version"]
+readme = { file = "README.md", content-type = "text/markdown" }
 description = "Numbast - auto Numba binding generation tool for CUDA C++."
 requires-python = ">=3.7"
 classifiers = [


### PR DESCRIPTION
Currently the description page on PyPI is empty. This PR uses readme.md as description.