### PR TITLE
Use `TargetRegistry.lower_cast` in separate registry mode

### DIFF
--- a/numbast/src/numbast/static/renderer.py
+++ b/numbast/src/numbast/static/renderer.py
@@ -22,6 +22,7 @@ target_registry = TargetRegistry()
 lower = target_registry.lower
 lower_attr = target_registry.lower_getattr
 lower_constant = target_registry.lower_constant
+lower_cast = target_registry.lower_cast
 """
 
     KeyedStringIO = """
@@ -341,7 +342,7 @@ def registry_setup(use_separate_registry: bool) -> str:
             "from numba.cuda.typing.templates import Registry as TypingRegistry"
         )
         BaseRenderer.Imports.add(
-            "from numba.core.imputils import Registry as TargetRegistry, lower_cast"
+            "from numba.core.imputils import Registry as TargetRegistry"
         )
         return BaseRenderer.SeparateRegistrySetup
     else:

--- a/numbast/src/numbast/static/struct.py
+++ b/numbast/src/numbast/static/struct.py
@@ -608,8 +608,6 @@ def {lower_scope_name}(shim_stream, shim_obj):
     def _render_lowering(self):
         """Render lowering codes for this struct constructor."""
 
-        self.Imports.add("from numba.core.extending import lower_cast")
-
         self._lowering_rendered = (
             self.struct_conversion_op_lowering_template.format(
                 struct_name=self._struct_name,


### PR DESCRIPTION
In separate registry mode, new instances of typing and target registries are created and added to CUDA's third party registry separately. This is in contrast to directly registerying to `cudaimpl` registry.

We expose most of the `register` functions, except `lower_cast`, which should also be shadowed by the custom target registry.