### PR TITLE
Enable apt proxy caching in workflows

### DIFF
--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -110,6 +110,8 @@ jobs:
       - name: Setup proxy cache
         uses: nv-gha-runners/setup-proxy-cache@main
         continue-on-error: true
+        with:
+          enable-apt: true
       - name: GitHub Metadata
         run: |
           GIT_DESCRIBE_TAG=$(git describe --abbrev=0)

--- a/.github/workflows/conda-python-test.yaml
+++ b/.github/workflows/conda-python-test.yaml
@@ -137,6 +137,8 @@ jobs:
       - name: Setup proxy cache
         uses: nv-gha-runners/setup-proxy-cache@main
         continue-on-error: true
+        with:
+          enable-apt: true
       - name: Python tests
         run: ${{ inputs.script }}
         env:

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -90,6 +90,8 @@ jobs:
       - name: Setup proxy cache
         uses: nv-gha-runners/setup-proxy-cache@main
         continue-on-error: true
+        with:
+          enable-apt: true
       - name: Cache build dependencies
         uses: actions/cache@v5
         with:

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -91,6 +91,8 @@ jobs:
       - name: Setup proxy cache
         uses: nv-gha-runners/setup-proxy-cache@main
         continue-on-error: true
+        with:
+          enable-apt: true
       - name: Ensure GPU is working
         run: nvidia-smi
       - name: Set up Python ${{ matrix.PY_VER }}


### PR DESCRIPTION
## Summary
- enable apt proxy caching for nv-gha-runners/setup-proxy-cache steps

## Test plan
- [ ] Not run (CI-only change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configurations to enable apt caching support across build and test pipelines.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->