### PR TITLE
docs: ensure releases publish versioned docs

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -124,7 +124,7 @@ jobs:
         uses: ./.github/actions/docs-build
         with:
           upload_workflow_artifact: "true"
-          latest_only: "true"
+          latest_only: ${{ inputs.is_release && 'false' || 'true' }}
           download_artifacts: ${{ inputs.download_artifacts && 'true' || 'false' }}
       - name: Create empty directory for cleanup
         if: ${{ inputs.remove_pr_preview }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,7 @@ The mainline release process for Numbast involves the following steps:
 
 - Make sure your local `main` branch is top-of-tree.
 - Open a PR to update `VERSION` in repo root to the desired version.
+- In the same PR, update `docs/nv-versions.json` and `docs/versions.json` to include the new release so the docs version picker includes it.
 - Generate a short changelog with `git log v<PREVIOUS_VERSION>..HEAD --oneline --pretty=format:"- %s"`.
 - Put the changelog in the version update PR description.
 - Once `main` is updated, tag the release:
@@ -64,6 +65,7 @@ v<VERSION>
 ```
 git push git@github.com:NVIDIA/numbast.git v<VERSION>
 ```
+- Verify docs deployment publishes `https://nvidia.github.io/numbast/<VERSION>/` and that `<VERSION>` appears in the docs version picker.
 
 ### Patch releases from a previous tag
 
@@ -77,7 +79,7 @@ git push -u origin <MAJOR.MINOR>.x-patch
 ```
 2. Use short-lived branches for fixes, and open PRs targeting `<MAJOR.MINOR>.x-patch`.
 3. Wait for CI and merge each fix PR into `<MAJOR.MINOR>.x-patch`.
-4. Open a PR that bumps repo-root `VERSION` to the patch version (for example `0.6.1`), targeting `<MAJOR.MINOR>.x-patch`.
+4. Open a PR that bumps repo-root `VERSION` to the patch version (for example `0.6.1`), and update `docs/nv-versions.json` plus `docs/versions.json` with that patch version, targeting `<MAJOR.MINOR>.x-patch`.
 5. Wait for CI and merge the version bump PR.
 6. Create and push an annotated tag from the tip of `<MAJOR.MINOR>.x-patch`:
 ```
@@ -88,6 +90,7 @@ cat /tmp/numbast-v<NEW_VERSION>-changelog.txt >> /tmp/numbast-v<NEW_VERSION>-tag
 git tag -a v<NEW_VERSION> -F /tmp/numbast-v<NEW_VERSION>-tag.txt
 git push origin v<NEW_VERSION>
 ```
+7. Verify docs deployment publishes `https://nvidia.github.io/numbast/<NEW_VERSION>/` and that `<NEW_VERSION>` appears in the docs version picker.
 
 Notes:
 - Use branch names that do not start with `v` for maintenance branches (for example, `0.6.x-patch`) to avoid accidental release automation triggers.


### PR DESCRIPTION
## Summary
- Update `CONTRIBUTING.md` release instructions to require updating `docs/nv-versions.json` and `docs/versions.json` when bumping release versions.
- Add explicit verification steps for release docs URLs and version-switcher entries after publishing.
- Update docs deployment workflow so release docs builds publish versioned docs (`latest_only: false`) while PR previews stay optimized (`latest_only: true`).

## Test plan
- [x] Run repository pre-commit hooks during commit.
- [x] Inspect workflow and docs diffs for expected release/docs behavior.
- [ ] Validate in CI that release docs deployment publishes both `/latest/` and `/<version>/` paths.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added release procedures to ensure documentation version pickers remain synchronized during mainline and patch releases, including verification steps.

* **Chores**
  * Updated documentation build workflow to conditionally manage versioning behavior during releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->