### PR TITLE
fix: mark workspace safe for Git invoked by python wheel build

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -119,6 +119,8 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
+      - name: Mark workspace safe for Git invoked by python wheel build
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Build docs
         if: ${{ !inputs.remove_pr_preview }}
         uses: ./.github/actions/docs-build

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -87,6 +87,8 @@ jobs:
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.sha }}
           fetch-depth: 0
+      - name: Mark workspace safe for Git invoked by python wheel build
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Setup proxy cache
         uses: nv-gha-runners/setup-proxy-cache@main
         continue-on-error: true


### PR DESCRIPTION
Explicit safe directory set is required when running inside a container due to
https://github.com/actions/checkout/issues/1169

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to improve Git operations in the build environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->