### PR TITLE
PyPi package name ast_canopy -> ast-canopy

### DIFF
--- a/ast_canopy/pyproject.toml
+++ b/ast_canopy/pyproject.toml
@@ -6,7 +6,7 @@ requires = ["scikit-build-core", "setuptools_scm", "pybind11"]
 build-backend = "scikit_build_core.build"
 
 [project]
-name = "ast_canopy"
+name = "ast-canopy"
 dynamic = ["version"]
 readme = { file = "README.md", content-type = "text/markdown" }
 dependencies = ["cuda-pathfinder>=1.3,<2"]

--- a/numbast/pyproject.toml
+++ b/numbast/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 dependencies = [
   "numba-cuda>=0.25.0",
-  "ast_canopy>=0.5.0",
+  "ast-canopy>=0.5.0",
   "pyyaml",
   "click",
   "jinja2",


### PR DESCRIPTION
Harmonize with the conda approach, in PyPi ast_canopy and ast-canopy are normalized and the same. We agreed to do this to keep package names in sync. From the external perspective both forms will still resolve to this package.

Closes #312.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated project distribution naming convention from underscore to hyphenated format (`ast_canopy` → `ast-canopy`).
* Updated dependency references to reflect the new distribution name across packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->