### PR TITLE
Add register_cxx_type public API

### DIFF
--- a/numbast/src/numbast/types.py
+++ b/numbast/src/numbast/types.py
@@ -91,6 +91,22 @@ NUMBA_TO_CTYPE_MAPS = {
 }
 
 
+def register_cxx_type(cxx_name: str, numba_type: nbtypes.Type):
+    """
+    Register an external C++ type in numbast's type registry.
+
+    After registration, ``to_numba_type(cxx_name)`` returns *numba_type*
+    instead of ``Opaque``. This is useful for binding types that were not
+    parsed by ast_canopy (e.g. third-party library types whose layout is
+    known but whose headers are too complex to parse).
+
+    Parameters:
+        cxx_name (str): The C++ type name as it appears in function signatures.
+        numba_type (nbtypes.Type): The Numba type to map it to.
+    """
+    CTYPE_MAPS[cxx_name] = numba_type
+
+
 def register_enum_type(
     cxx_name: str,
     e: type[Enum],

--- a/numbast/tests/test_register_cxx_type.py
+++ b/numbast/tests/test_register_cxx_type.py
@@ -10,9 +10,19 @@ of ``Opaque``. This is how external types (e.g. ``Eigen::half``) get
 mapped to ``float16`` when their real headers are too complex to parse.
 """
 
+import pytest
 from numba import types as nbtypes
 
-from numbast.types import register_cxx_type, to_numba_type
+from numbast.types import CTYPE_MAPS, register_cxx_type, to_numba_type
+
+
+@pytest.fixture(autouse=True)
+def _restore_ctype_maps():
+    """Snapshot and restore CTYPE_MAPS so tests don't pollute the global registry."""
+    snapshot = dict(CTYPE_MAPS)
+    yield
+    CTYPE_MAPS.clear()
+    CTYPE_MAPS.update(snapshot)
 
 
 def test_unregistered_type_is_opaque():

--- a/numbast/tests/test_register_cxx_type.py
+++ b/numbast/tests/test_register_cxx_type.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Standalone test for ``numbast.types.register_cxx_type``.
+
+``register_cxx_type`` lets callers register a C++ type name in numbast's
+type registry without parsing it from a header. After registration,
+``to_numba_type(cxx_name)`` resolves to the registered numba type instead
+of ``Opaque``. This is how external types (e.g. ``Eigen::half``) get
+mapped to ``float16`` when their real headers are too complex to parse.
+"""
+
+from numba import types as nbtypes
+
+from numbast.types import register_cxx_type, to_numba_type
+
+
+def test_unregistered_type_is_opaque():
+    """Before registration, to_numba_type returns an Opaque type."""
+    result = to_numba_type("SomeLibrary::Unregistered_abc123")
+    assert isinstance(result, nbtypes.Opaque)
+
+
+def test_register_maps_to_numba_scalar():
+    """Registering a C++ name routes it to the given numba scalar type."""
+    cxx_name = "SomeLibrary::MyHalf_abc123"
+    register_cxx_type(cxx_name, nbtypes.float16)
+
+    result = to_numba_type(cxx_name)
+    assert result is nbtypes.float16
+
+
+def test_register_overwrites_previous_registration():
+    """Re-registering the same name swaps the mapping."""
+    cxx_name = "SomeLibrary::Swappable_abc123"
+    register_cxx_type(cxx_name, nbtypes.int32)
+    assert to_numba_type(cxx_name) is nbtypes.int32
+
+    register_cxx_type(cxx_name, nbtypes.float64)
+    assert to_numba_type(cxx_name) is nbtypes.float64


### PR DESCRIPTION
## Summary

- Adds `numbast.types.register_cxx_type(cxx_name, numba_type)`, which registers an external C++ type name in `CTYPE_MAPS` so that `to_numba_type()` returns the given numba type instead of `Opaque`.
- Useful for binding types whose real headers are too complex to parse through ast_canopy, but whose memory layout is known and can be represented as an existing numba type (e.g. `Eigen::half` → `float16`, `Eigen::bfloat16` → numba `bfloat16`).
- Companion to the `bind_cxx_struct(name=...)` override (separate PR) — together they make binding class template specializations of external types practical.

## Test plan

- [x] New unit tests in `numbast/tests/test_register_cxx_type.py`:
  - Before registration, `to_numba_type` returns an `Opaque` type.
  - After registration, it returns the registered numba scalar type.
  - Re-registering the same name swaps the mapping.
- [x] `pytest numbast/tests/test_register_cxx_type.py` passes locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ability to register custom C++ type mappings to Numba types, allowing user-defined C++ type names to resolve to specific Numba types instead of default opaque placeholders.

* **Tests**
  * Added tests ensuring unregistered names return opaque types, custom registrations resolve to the exact mapped Numba types, and re-registering overwrites previous mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->