### PR TITLE
Add name= override to bind_cxx_struct

### DIFF
--- a/numbast/src/numbast/struct.py
+++ b/numbast/src/numbast/struct.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import re
 from typing import Any, Optional
 from collections import defaultdict
 
@@ -47,6 +48,16 @@ extern "C" __device__ int
     return 0;
 }}
 """
+
+
+def _sanitize_c_identifier(s: str) -> str:
+    """Replace characters invalid in a C identifier with underscores.
+
+    Needed when struct_name is a fully-qualified template specialization
+    (e.g. ``Eigen::Matrix<float, 3, 1>``) and is embedded into a shim
+    function symbol.
+    """
+    return re.sub(r"[^A-Za-z0-9_]", "_", s)
 
 
 def bind_cxx_struct_ctor(
@@ -200,8 +211,13 @@ def bind_cxx_struct_conversion_opeartor(
     casted_type = to_numba_type(conv.return_type.unqualified_non_ref_type_name)
 
     # Lowering:
+    # struct_name may be a fully-qualified template specialization (e.g.
+    # "Eigen::Matrix<float, 3, 1>"), which is a valid C++ type reference
+    # but not a valid C identifier — sanitize before embedding in the
+    # shim symbol.
+    safe_struct_name = _sanitize_c_identifier(struct_name)
     mangled_name = deduplicate_overloads(
-        f"__{struct_name}__{conv.mangled_name}"
+        f"__{safe_struct_name}__{conv.mangled_name}"
     )
     shim_func_name = f"{mangled_name}_nbst"
 

--- a/numbast/src/numbast/struct.py
+++ b/numbast/src/numbast/struct.py
@@ -493,8 +493,11 @@ def bind_cxx_struct(
     # It also needs to happen before method typings - because copy constructors
     # needs to know the type of itself even if the definition is incomplete.
     C2N[struct_name] = s_type
-    if struct_name in aliases:
-        for alias in aliases[struct_name]:
+    alias_keys = (struct_name,)
+    if struct_decl.name != struct_name:
+        alias_keys = (struct_name, struct_decl.name)
+    for alias_key in alias_keys:
+        for alias in aliases.get(alias_key, []):
             C2N[alias] = s_type
 
     # Data Model

--- a/numbast/src/numbast/struct.py
+++ b/numbast/src/numbast/struct.py
@@ -138,6 +138,7 @@ def bind_cxx_struct_ctor(
 
 def bind_cxx_struct_ctors(
     struct_decl: Struct,
+    struct_name: str,
     S: object,
     s_type: nbtypes.Type,
     shim_writer: ShimWriter,
@@ -149,6 +150,8 @@ def bind_cxx_struct_ctors(
 
     struct_decl: Struct
         The declaration of the struct in CXX
+    struct_name: str
+        The C++ name to use in shim code (may differ from struct_decl.name).
     S: object
         The Python API of the struct
     s_type: numba.types.Type
@@ -160,7 +163,7 @@ def bind_cxx_struct_ctors(
     ctor_params: list[list[Any]] = []
     for ctor in struct_decl.constructors():
         param_types = bind_cxx_struct_ctor(
-            ctor, struct_decl.name, s_type, S, shim_writer
+            ctor, struct_name, s_type, S, shim_writer
         )
         if param_types is not None:
             ctor_params.append(param_types)
@@ -226,17 +229,21 @@ def bind_cxx_struct_conversion_opeartor(
 
 
 def bind_cxx_struct_conversion_opeartors(
-    struct_decl: Struct, s_type: nbtypes.Type, shim_writer: ShimWriter
+    struct_decl: Struct,
+    struct_name: str,
+    s_type: nbtypes.Type,
+    shim_writer: ShimWriter,
 ):
     """Bind all conversion operators for a C++ struct."""
     for conv in struct_decl.conversion_operators():
         bind_cxx_struct_conversion_opeartor(
-            conv, struct_decl.name, s_type, shim_writer
+            conv, struct_name, s_type, shim_writer
         )
 
 
 def bind_cxx_struct_regular_method(
     struct_decl: Struct,
+    struct_name: str,
     method_decl: StructMethod,
     s_type: nbtypes.Type,
     shim_writer: ShimWriter,
@@ -266,7 +273,7 @@ def bind_cxx_struct_regular_method(
 
     overrides = None
     if arg_intent:
-        overrides = arg_intent.get(f"{struct_decl.name}.{method_decl.name}")
+        overrides = arg_intent.get(f"{struct_name}.{method_decl.name}")
 
     if overrides is None:
         param_types = [
@@ -336,7 +343,7 @@ def bind_cxx_struct_regular_method(
 
     shim = make_struct_regular_method_shim(
         shim_name=shim_func_name,
-        struct_name=struct_decl.name,
+        struct_name=struct_name,
         method_name=method_decl.name,
         return_type=method_decl.return_type.unqualified_non_ref_type_name,
         params=method_decl.params,
@@ -363,6 +370,7 @@ def bind_cxx_struct_regular_method(
 
 def bind_cxx_struct_regular_methods(
     struct_decl: Struct,
+    struct_name: str,
     s_type: nbtypes.Type,
     shim_writer: ShimWriter,
     *,
@@ -387,7 +395,12 @@ def bind_cxx_struct_regular_methods(
 
     for method in struct_decl.regular_member_functions():
         sig = bind_cxx_struct_regular_method(
-            struct_decl, method, s_type, shim_writer, arg_intent=arg_intent
+            struct_decl,
+            struct_name,
+            method,
+            s_type,
+            shim_writer,
+            arg_intent=arg_intent,
         )
         method_overloads[method.name].append(sig)
 
@@ -414,6 +427,7 @@ def bind_cxx_struct(
     ] = {},  # XXX: this should be just a list of aliases
     *,
     arg_intent: dict | None = None,
+    name: str | None = None,
 ) -> object:
     """
     Create and register a Numba API type and associated bindings for a C++ struct.
@@ -433,30 +447,38 @@ def bind_cxx_struct(
             Mapping from the struct's canonical name to alternate names that should resolve to the same type.
         arg_intent: dict | None, optional
             Optional overrides that guide argument intent (in/out/inout) and influence method overload lowering.
+        name: str | None, optional
+            Override the C++ name used for this struct in the Numba type system and shim code.
+            When provided, this name is used instead of struct_decl.name for type registration,
+            shim generation, and the Python API class name. Useful for binding class template
+            specializations where struct_decl.name is the unqualified template name (e.g. "Matrix")
+            but the shim needs the fully qualified specialization (e.g. "Eigen::Matrix<float,3,1>").
 
     Returns:
         S: object
             The Python-facing Numba API type for the bound C++ struct.
     """
 
+    struct_name = name if name is not None else struct_decl.name
+
     # Typing
     class S_type(parent_type):
         def __init__(self, decl):
-            super().__init__(name=f"{struct_decl.name}")
+            super().__init__(name=struct_name)
             self.alignof_ = struct_decl.alignof_
             self.bitwidth = struct_decl.sizeof_ * 8
 
     s_type = S_type(struct_decl)
 
     # Python API
-    S = type(struct_decl.name, (), {"_nbtype": s_type})
+    S = type(struct_name, (), {"_nbtype": s_type})
 
     # Any type that was parsed from C++ should be added to type record:
     # It also needs to happen before method typings - because copy constructors
     # needs to know the type of itself even if the definition is incomplete.
-    C2N[struct_decl.name] = s_type
-    if struct_decl.name in aliases:
-        for alias in aliases[struct_decl.name]:
+    C2N[struct_name] = s_type
+    if struct_name in aliases:
+        for alias in aliases[struct_name]:
             C2N[alias] = s_type
 
     # Data Model
@@ -487,7 +509,7 @@ def bind_cxx_struct(
         # Method, Attributes Typing and Lowering:
 
         method_templates = bind_cxx_struct_regular_methods(
-            struct_decl, s_type, shim_writer, arg_intent=arg_intent
+            struct_decl, struct_name, s_type, shim_writer, arg_intent=arg_intent
         )
 
         public_fields_tys = {
@@ -519,11 +541,13 @@ def bind_cxx_struct(
 
     # ----------------------------------------------------------------------------------
     # Constructors:
-    bind_cxx_struct_ctors(struct_decl, S, s_type, shim_writer)
+    bind_cxx_struct_ctors(struct_decl, struct_name, S, s_type, shim_writer)
 
     # ----------------------------------------------------------------------------------
     # Conversion operators:
-    bind_cxx_struct_conversion_opeartors(struct_decl, s_type, shim_writer)
+    bind_cxx_struct_conversion_opeartors(
+        struct_decl, struct_name, s_type, shim_writer
+    )
 
     # Return the handle to the type in Numba
     return S

--- a/numbast/tests/data/sample_name_override.cuh
+++ b/numbast/tests/data/sample_name_override.cuh
@@ -13,6 +13,10 @@
 namespace demo {
 template <typename T, int N> struct Vec {
   T data[N];
+  // A conversion operator forces the bind path that composes a shim
+  // symbol from struct_name — that symbol must remain a valid C
+  // identifier even when struct_name contains template syntax.
+  __device__ operator T() const { return data[0]; }
 };
 } // namespace demo
 

--- a/numbast/tests/data/sample_name_override.cuh
+++ b/numbast/tests/data/sample_name_override.cuh
@@ -1,0 +1,23 @@
+// clang-format off
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+// clang-format on
+
+#pragma once
+
+// A trivial class template whose specialization we want to bind with a
+// custom C++ name. struct_decl.name for the specialization is just the
+// unqualified template name ("Vec"), but in real shim code we need the
+// fully qualified specialization (e.g. "demo::Vec<float, 3>").
+
+namespace demo {
+template <typename T, int N> struct Vec {
+  T data[N];
+};
+} // namespace demo
+
+// Force instantiation so the class_template_specialization shows up in
+// the parsed declarations.
+struct ForceInstantiation {
+  demo::Vec<float, 3> v3f;
+};

--- a/numbast/tests/test_bind_cxx_struct_name_override.py
+++ b/numbast/tests/test_bind_cxx_struct_name_override.py
@@ -12,12 +12,23 @@ on ``bind_cxx_struct`` lets callers supply the fully-qualified name.
 
 import os
 
+import pytest
 from numba import types as nbtypes
 from numba.cuda.datamodel.models import StructModel
 
 from ast_canopy import parse_declarations_from_source
 from numbast import bind_cxx_struct, MemoryShimWriter
 from numbast.types import CTYPE_MAPS, to_numba_type
+
+
+@pytest.fixture(autouse=True)
+def _restore_ctype_maps():
+    """Snapshot and restore CTYPE_MAPS so bind_cxx_struct side effects
+    don't leak across tests."""
+    snapshot = dict(CTYPE_MAPS)
+    yield
+    CTYPE_MAPS.clear()
+    CTYPE_MAPS.update(snapshot)
 
 
 def _parse_specialization():
@@ -70,3 +81,19 @@ def test_bind_with_name_uses_override_everywhere():
     assert S.__name__ == override
     assert CTYPE_MAPS.get(override) is S._nbtype
     assert to_numba_type(override) is S._nbtype
+
+
+def test_sanitize_c_identifier_strips_template_syntax():
+    """When a fully-qualified template specialization is passed via
+    ``name=``, it is embedded in the conversion-operator shim symbol.
+    ``_sanitize_c_identifier`` must rewrite every character outside
+    ``[A-Za-z0-9_]`` (``:``, ``<``, ``>``, ``,``, spaces) to keep the
+    resulting C symbol valid."""
+    import re
+
+    from numbast.struct import _sanitize_c_identifier
+
+    result = _sanitize_c_identifier("Eigen::Matrix<float, 3, 1>")
+    assert re.fullmatch(r"[A-Za-z0-9_]+", result)
+    assert "<" not in result and ">" not in result
+    assert ":" not in result and "," not in result

--- a/numbast/tests/test_bind_cxx_struct_name_override.py
+++ b/numbast/tests/test_bind_cxx_struct_name_override.py
@@ -83,6 +83,33 @@ def test_bind_with_name_uses_override_everywhere():
     assert to_numba_type(override) is S._nbtype
 
 
+def test_bind_with_name_honors_aliases_from_typedef_names():
+    """Typedef-derived aliases are keyed by the parsed declaration name.
+
+    ``name=`` changes the effective C++ type name used by the binding, but it
+    must not drop aliases produced from typedefs of the original parsed name.
+    """
+    cts = _parse_specialization()
+    shim_writer = MemoryShimWriter("")
+    override = "demo::Vec<float, 3>"
+    aliases = {
+        "Vec": ["VecAliasFromTypedef"],
+        override: ["VecAliasFromOverride"],
+    }
+
+    S = bind_cxx_struct(
+        shim_writer,
+        cts,
+        nbtypes.Type,
+        StructModel,
+        aliases=aliases,
+        name=override,
+    )
+
+    assert to_numba_type("VecAliasFromTypedef") is S._nbtype
+    assert to_numba_type("VecAliasFromOverride") is S._nbtype
+
+
 def test_sanitize_c_identifier_strips_template_syntax():
     """When a fully-qualified template specialization is passed via
     ``name=``, it is embedded in the conversion-operator shim symbol.

--- a/numbast/tests/test_bind_cxx_struct_name_override.py
+++ b/numbast/tests/test_bind_cxx_struct_name_override.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Standalone test for the ``name=`` override on ``bind_cxx_struct``.
+
+For a class template specialization, ``struct_decl.name`` is just the
+unqualified template name (e.g. ``"Vec"``), but the Numba type name,
+CTYPE_MAPS key, and shim code all need the fully qualified
+specialization (e.g. ``"demo::Vec<float, 3>"``). The ``name=`` keyword
+on ``bind_cxx_struct`` lets callers supply the fully-qualified name.
+"""
+
+import os
+
+from numba import types as nbtypes
+from numba.cuda.datamodel.models import StructModel
+
+from ast_canopy import parse_declarations_from_source
+from numbast import bind_cxx_struct, MemoryShimWriter
+from numbast.types import CTYPE_MAPS, to_numba_type
+
+
+def _parse_specialization():
+    header = os.path.join(
+        os.path.dirname(__file__), "data", "sample_name_override.cuh"
+    )
+    decls = parse_declarations_from_source(header, [header], "sm_80")
+    specs = [
+        cts
+        for cts in decls.class_template_specializations
+        if "Vec" in cts.name
+    ]
+    assert specs, "expected Vec<float, 3> specialization to be parsed"
+    return specs[0]
+
+
+def test_specialization_name_is_unqualified_by_default():
+    """Guard: struct_decl.name on the parsed specialization is the short
+    template name. This is the reason the override is needed."""
+    cts = _parse_specialization()
+    assert cts.name == "Vec"
+
+
+def test_bind_without_name_uses_struct_decl_name():
+    """Without ``name=``, numba type name and CTYPE_MAPS key use the
+    unqualified specialization name from struct_decl."""
+    cts = _parse_specialization()
+    shim_writer = MemoryShimWriter("")
+    S = bind_cxx_struct(shim_writer, cts, nbtypes.Type, StructModel)
+
+    assert S._nbtype.name == "Vec"
+    assert CTYPE_MAPS.get("Vec") is S._nbtype
+    assert to_numba_type("Vec") is S._nbtype
+
+
+def test_bind_with_name_uses_override_everywhere():
+    """With ``name=``, the override drives Numba type name, Python API
+    class name, and the CTYPE_MAPS registration key."""
+    cts = _parse_specialization()
+    shim_writer = MemoryShimWriter("")
+    override = "demo::Vec<float, 3>"
+
+    S = bind_cxx_struct(
+        shim_writer, cts, nbtypes.Type, StructModel, name=override,
+    )
+
+    assert S._nbtype.name == override
+    assert S.__name__ == override
+    assert CTYPE_MAPS.get(override) is S._nbtype
+    assert to_numba_type(override) is S._nbtype

--- a/numbast/tests/test_bind_cxx_struct_name_override.py
+++ b/numbast/tests/test_bind_cxx_struct_name_override.py
@@ -26,9 +26,7 @@ def _parse_specialization():
     )
     decls = parse_declarations_from_source(header, [header], "sm_80")
     specs = [
-        cts
-        for cts in decls.class_template_specializations
-        if "Vec" in cts.name
+        cts for cts in decls.class_template_specializations if "Vec" in cts.name
     ]
     assert specs, "expected Vec<float, 3> specialization to be parsed"
     return specs[0]
@@ -61,7 +59,11 @@ def test_bind_with_name_uses_override_everywhere():
     override = "demo::Vec<float, 3>"
 
     S = bind_cxx_struct(
-        shim_writer, cts, nbtypes.Type, StructModel, name=override,
+        shim_writer,
+        cts,
+        nbtypes.Type,
+        StructModel,
+        name=override,
     )
 
     assert S._nbtype.name == override


### PR DESCRIPTION
## Summary

- Adds an optional keyword `name=` to `bind_cxx_struct` that overrides `struct_decl.name` throughout: the Numba type name, the Python API class name, the `CTYPE_MAPS` registration key, and the shim template substitutions.
- Motivation: when binding a class template specialization, `struct_decl.name` is just the unqualified template name (e.g. `"Matrix"`), but the shim code and type registry both need the fully qualified specialization name (e.g. `"Namespace::Matrix<float, 3, 1>"`).
- The override is plumbed through `bind_cxx_struct_ctors`, `bind_cxx_struct_regular_methods`, and `bind_cxx_struct_conversion_opeartors` so every downstream consumer sees the same name.

## Test plan

- [x] New unit tests in `numbast/tests/test_bind_cxx_struct_name_override.py` against a fresh stub header with a `demo::Vec<float,3>` specialization:
  - Guard: parsed `struct_decl.name` on the specialization is `"Vec"` (motivates the override).
  - Without `name=`, the Numba type name and `CTYPE_MAPS` key use the unqualified specialization name.
  - With `name=`, the override drives Numba type name, Python API class name, and `CTYPE_MAPS` registration key.
- [x] `pytest numbast/tests/test_bind_cxx_struct_name_override.py` passes locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional name-override for struct binding so custom (including fully-qualified) names are used for Python-facing types and type registration; generated shim symbols are sanitized into valid C identifiers.

* **Tests**
  * New tests and sample data verifying default unqualified names, name-override propagation across APIs, preservation of aliases, and sanitization of fully-qualified template names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->