### PR TITLE
ast_canopy: skip Itanium mangling for dependent-signature functions

### DIFF
--- a/ast_canopy/cpp/src/function.cpp
+++ b/ast_canopy/cpp/src/function.cpp
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <iostream>
 #include <memory>
+#include <string>
 
 namespace ast_canopy {
 
@@ -54,6 +55,79 @@ static bool has_dependent_signature(const clang::FunctionDecl *FD) {
   return false;
 }
 
+static bool is_identifier_alnum(unsigned char c) {
+  return ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') ||
+         ('0' <= c && c <= '9');
+}
+
+static std::string encode_identifier_fragment(const std::string &input) {
+  static constexpr char hex[] = "0123456789ABCDEF";
+  std::string output;
+  output.reserve(input.size());
+  for (unsigned char c : input) {
+    if (is_identifier_alnum(c)) {
+      output.push_back(static_cast<char>(c));
+    } else {
+      output += "_x";
+      output.push_back(hex[c >> 4]);
+      output.push_back(hex[c & 0x0F]);
+    }
+  }
+  return output;
+}
+
+/**
+ * @brief Build an overload-stable fallback name for dependent signatures.
+ *
+ * This is not an Itanium-mangled symbol.  It includes byte-encoded printed
+ * signature fragments to keep dependent overloads distinct without asking
+ * Clang's mangler to process unresolved template-dependent types.
+ */
+static std::string
+make_dependent_signature_fallback(const clang::FunctionDecl *FD,
+                                  const std::string &base_name) {
+  const clang::PrintingPolicy &policy = FD->getASTContext().getPrintingPolicy();
+
+  std::string fallback = encode_identifier_fragment(base_name);
+  fallback += "__dependent_signature__returns__";
+  fallback +=
+      encode_identifier_fragment(FD->getReturnType().getAsString(policy));
+  fallback += "__params__";
+
+  if (FD->parameters().empty()) {
+    fallback += "void";
+  } else {
+    bool first = true;
+    for (const auto *P : FD->parameters()) {
+      if (!first)
+        fallback += "__";
+      first = false;
+      fallback += encode_identifier_fragment(P->getType().getAsString(policy));
+    }
+  }
+
+  if (const auto *FPT = FD->getType()->getAs<clang::FunctionProtoType>()) {
+    std::string method_quals = FPT->getMethodQuals().getAsString(policy);
+    if (!method_quals.empty()) {
+      fallback += "__quals__";
+      fallback += encode_identifier_fragment(method_quals);
+    }
+
+    switch (FPT->getRefQualifier()) {
+    case clang::RQ_LValue:
+      fallback += "__ref__lvalue";
+      break;
+    case clang::RQ_RValue:
+      fallback += "__ref__rvalue";
+      break;
+    case clang::RQ_None:
+      break;
+    }
+  }
+
+  return fallback;
+}
+
 Function::Function(const clang::FunctionDecl *FD)
     : name(FD->getNameAsString()), qual_name(FD->getQualifiedNameAsString()),
       return_type(FD->getReturnType(), FD->getASTContext()),
@@ -77,7 +151,7 @@ Function::Function(const clang::FunctionDecl *FD)
   // are still template-dependent (e.g. methods of uninstantiated class
   // templates such as Eigen::Matrix<Scalar_,...>).
   if (has_dependent_signature(FD)) {
-    mangled_name = qual_name; // best-effort fallback
+    mangled_name = make_dependent_signature_fallback(FD, qual_name);
   } else {
     auto &context = FD->getASTContext();
     auto &diag = context.getDiagnostics();

--- a/ast_canopy/cpp/src/function.cpp
+++ b/ast_canopy/cpp/src/function.cpp
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <iostream>
+#include <memory>
 
 namespace ast_canopy {
 
@@ -27,6 +28,30 @@ execution_space get_execution_space(const clang::FunctionDecl *FD) {
   } else {
     return execution_space::undefined;
   }
+}
+
+/**
+ * @brief Return true if the function has a dependent (unresolved) signature.
+ *
+ * Mangling or querying canonical types on such a function is undefined and
+ * can crash the Clang mangler (segfault).  We detect this upfront so callers
+ * can skip or guard the operation.
+ */
+static bool has_dependent_signature(const clang::FunctionDecl *FD) {
+  if (FD->getReturnType()->isDependentType())
+    return true;
+  for (const auto *P : FD->parameters()) {
+    if (P->getType()->isDependentType())
+      return true;
+  }
+  // Also flag methods whose parent class is dependent.
+  if (const auto *MD = clang::dyn_cast<clang::CXXMethodDecl>(FD)) {
+    if (const auto *Parent = MD->getParent()) {
+      if (Parent->isDependentContext())
+        return true;
+    }
+  }
+  return false;
 }
 
 Function::Function(const clang::FunctionDecl *FD)
@@ -46,25 +71,33 @@ Function::Function(const clang::FunctionDecl *FD)
     this->attributes.insert(attr->getSpelling());
   }
 
-  // Compute itanium mangled name
-  auto &context = FD->getASTContext();
-  auto &diag = context.getDiagnostics();
-  clang::ItaniumMangleContext *MC =
-      clang::ItaniumMangleContext::create(context, diag);
-  llvm::raw_string_ostream OS(mangled_name);
-
-  clang::GlobalDecl GD;
-  if (const clang::CXXConstructorDecl *CCD =
-          clang::dyn_cast<clang::CXXConstructorDecl>(FD)) {
-    GD = clang::GlobalDecl(CCD, clang::Ctor_Complete);
-  } else if (const clang::CXXDestructorDecl *CDD =
-                 clang::dyn_cast<clang::CXXDestructorDecl>(FD)) {
-    GD = clang::GlobalDecl(CDD, clang::Dtor_Complete);
+  // Compute itanium mangled name.
+  // Skip mangling for functions with dependent (unresolved) signatures --
+  // the Clang Itanium mangler can segfault when asked to mangle types that
+  // are still template-dependent (e.g. methods of uninstantiated class
+  // templates such as Eigen::Matrix<Scalar_,...>).
+  if (has_dependent_signature(FD)) {
+    mangled_name = qual_name; // best-effort fallback
   } else {
-    GD = clang::GlobalDecl(FD);
-  }
+    auto &context = FD->getASTContext();
+    auto &diag = context.getDiagnostics();
+    std::unique_ptr<clang::ItaniumMangleContext> MC(
+        clang::ItaniumMangleContext::create(context, diag));
+    llvm::raw_string_ostream OS(mangled_name);
 
-  MC->mangleName(GD, OS);
-  OS.flush();
+    clang::GlobalDecl GD;
+    if (const clang::CXXConstructorDecl *CCD =
+            clang::dyn_cast<clang::CXXConstructorDecl>(FD)) {
+      GD = clang::GlobalDecl(CCD, clang::Ctor_Complete);
+    } else if (const clang::CXXDestructorDecl *CDD =
+                   clang::dyn_cast<clang::CXXDestructorDecl>(FD)) {
+      GD = clang::GlobalDecl(CDD, clang::Dtor_Complete);
+    } else {
+      GD = clang::GlobalDecl(FD);
+    }
+
+    MC->mangleName(GD, OS);
+    OS.flush();
+  }
 }
 } // namespace ast_canopy

--- a/ast_canopy/tests/data/sample_crtp_dependent.cu
+++ b/ast_canopy/tests/data/sample_crtp_dependent.cu
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Minimal repro for the mangleName segfault in
+// ast_canopy/cpp/src/function.cpp.
+//
+// The Itanium name mangler segfaults when handed a CXXMethodDecl whose
+// signature is still template-dependent (parameter or return types that
+// refer to template parameters not yet bound to concrete types). This
+// happens for any method declared inside a class template, e.g. CRTP
+// base classes or Eigen expression templates.
+//
+// The fix detects dependent signatures up-front with
+// has_dependent_signature() and skips mangling -- using the qualified
+// name as a best-effort fallback. It also plugs a leak by wrapping the
+// ItaniumMangleContext in a unique_ptr.
+
+#pragma once
+
+// Case A: CRTP base with a method whose return type depends on the
+// derived type. Parsing CRTPBase<T> was enough to segfault the mangler.
+template <typename Derived> struct CRTPBase {
+  __device__ Derived &derived() { return static_cast<Derived &>(*this); }
+  __device__ Derived add(const Derived &other) const { return derived(); }
+};
+
+template <typename Scalar> struct Vec3 : public CRTPBase<Vec3<Scalar>> {
+  Scalar x, y, z;
+  __host__ __device__ Vec3() : x(0), y(0), z(0) {}
+};
+
+// Case B: Function template whose return type depends on T::value_type.
+template <typename T>
+__device__ typename T::value_type extract_value(const T &container);
+
+// A concrete device function that should still be parsed with a
+// computed mangled name. Proves the non-dependent path is unchanged.
+__device__ float vec3_dot(Vec3<float> a, Vec3<float> b) {
+  return a.x * b.x + a.y * b.y + a.z * b.z;
+}

--- a/ast_canopy/tests/data/sample_crtp_dependent.cu
+++ b/ast_canopy/tests/data/sample_crtp_dependent.cu
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+// All rights reserved. SPDX-License-Identifier: Apache-2.0
 
 // Minimal repro for the mangleName segfault in
 // ast_canopy/cpp/src/function.cpp.

--- a/ast_canopy/tests/data/sample_crtp_dependent.cu
+++ b/ast_canopy/tests/data/sample_crtp_dependent.cu
@@ -11,8 +11,8 @@
 // base classes or Eigen expression templates.
 //
 // The fix detects dependent signatures up-front with
-// has_dependent_signature() and skips mangling -- using the qualified
-// name as a best-effort fallback. It also plugs a leak by wrapping the
+// has_dependent_signature() and skips Itanium mangling, using an explicit
+// dependent-signature fallback. It also plugs a leak by wrapping the
 // ItaniumMangleContext in a unique_ptr.
 
 #pragma once

--- a/ast_canopy/tests/data/sample_crtp_dependent.cu
+++ b/ast_canopy/tests/data/sample_crtp_dependent.cu
@@ -21,6 +21,9 @@
 // derived type. Parsing CRTPBase<T> was enough to segfault the mangler.
 template <typename Derived> struct CRTPBase {
   __device__ Derived &derived() { return static_cast<Derived &>(*this); }
+  __device__ const Derived &derived() const {
+    return static_cast<const Derived &>(*this);
+  }
   __device__ Derived add(const Derived &other) const { return derived(); }
 };
 

--- a/ast_canopy/tests/test_crtp_dependent_mangle.py
+++ b/ast_canopy/tests/test_crtp_dependent_mangle.py
@@ -12,10 +12,10 @@ Because ast_canopy unconditionally mangled every function it visited,
 return type depended on its parameters (e.g. Eigen's expression
 templates) would segfault the Python interpreter.
 
-The fix introduces ``has_dependent_signature(FD)`` and skips mangling
-(using the qualified name as a fallback) when the signature is still
-dependent. It also replaces a raw ``create`` with a ``unique_ptr`` to
-plug a leak.
+The fix introduces ``has_dependent_signature(FD)`` and skips Itanium
+mangling when the signature is still dependent, using an explicit
+dependent-signature fallback instead. It also replaces a raw ``create``
+with a ``unique_ptr`` to plug a leak.
 """
 
 import os
@@ -50,8 +50,17 @@ def test_dependent_function_template_captured(source_path):
     """extract_value has a dependent return type. It should appear as a
     function template without having segfaulted the mangler."""
     decls = parse_declarations_from_source(source_path, [source_path], "sm_80")
-    ft_names = [ft.function.name for ft in decls.function_templates]
-    assert "extract_value" in ft_names, ft_names
+    funcs = [
+        ft.function
+        for ft in decls.function_templates
+        if ft.function.name == "extract_value"
+    ]
+    assert funcs, [ft.function.name for ft in decls.function_templates]
+
+    mangled = funcs[0].mangled_name
+    assert mangled
+    assert not mangled.startswith("_Z"), mangled
+    assert "dependent_signature" in mangled, mangled
 
 
 def test_non_dependent_function_still_mangled(source_path):

--- a/ast_canopy/tests/test_crtp_dependent_mangle.py
+++ b/ast_canopy/tests/test_crtp_dependent_mangle.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Standalone test for the dependent-signature mangle guard in
+``ast_canopy/cpp/src/function.cpp``.
+
+Calling ``clang::ItaniumMangleContext::mangleName`` on a ``FunctionDecl``
+whose parameter or return types are still template-dependent segfaults
+the host process (the mangler dereferences uninstantiated type nodes).
+Because ast_canopy unconditionally mangled every function it visited,
+*any* header containing a CRTP base class or a function template whose
+return type depended on its parameters (e.g. Eigen's expression
+templates) would segfault the Python interpreter.
+
+The fix introduces ``has_dependent_signature(FD)`` and skips mangling
+(using the qualified name as a fallback) when the signature is still
+dependent. It also replaces a raw ``create`` with a ``unique_ptr`` to
+plug a leak.
+"""
+
+import os
+
+import pytest
+
+from ast_canopy import parse_declarations_from_source
+
+
+@pytest.fixture(scope="module")
+def source_path():
+    here = os.path.dirname(os.path.abspath(__file__))
+    return os.path.join(here, "data", "sample_crtp_dependent.cu")
+
+
+def test_crtp_header_does_not_segfault(source_path):
+    """Parsing a CRTP base with dependent-signature methods must not
+    crash the process."""
+    decls = parse_declarations_from_source(source_path, [source_path], "sm_80")
+    assert decls is not None
+
+
+def test_crtp_templates_are_captured(source_path):
+    """Both CRTPBase and Vec3 class templates should be parsed."""
+    decls = parse_declarations_from_source(source_path, [source_path], "sm_80")
+    names = [ct.qual_name for ct in decls.class_templates]
+    assert any("CRTPBase" in n for n in names), names
+    assert any("Vec3" in n for n in names), names
+
+
+def test_dependent_function_template_captured(source_path):
+    """extract_value has a dependent return type. It should appear as a
+    function template without having segfaulted the mangler."""
+    decls = parse_declarations_from_source(source_path, [source_path], "sm_80")
+    ft_names = [ft.function.name for ft in decls.function_templates]
+    assert "extract_value" in ft_names, ft_names
+
+
+def test_non_dependent_function_still_mangled(source_path):
+    """The fix must not regress mangling for concrete device functions:
+    vec3_dot should have a non-empty Itanium-style mangled name."""
+    decls = parse_declarations_from_source(source_path, [source_path], "sm_80")
+    funcs = {f.name: f for f in decls.functions}
+    assert "vec3_dot" in funcs
+    mangled = funcs["vec3_dot"].mangled_name
+    # Itanium mangling prefixes with `_Z`.
+    assert mangled.startswith("_Z"), mangled


### PR DESCRIPTION
## Summary

- `clang::ItaniumMangleContext::mangleName` **segfaults** when handed a `FunctionDecl` whose parameter or return types are still template-dependent. Because the `Function` constructor unconditionally mangled every `FunctionDecl` it visited, any header containing a CRTP base class, a function template with a dependent return type, or Eigen-style expression templates would segfault the whole Python process.
- Introduces `has_dependent_signature(FD)`, which returns true when the return type is dependent, any parameter type is dependent, or the parent (for methods) is a dependent context. When it returns true, mangling is skipped and the qualified name is used as a best-effort fallback.
- Also plugs a leak: wraps the `ItaniumMangleContext` handle in `std::unique_ptr` (`create()` allocates with raw `new` but there was no matching `delete`).

## Test plan

- [x] New sample `ast_canopy/tests/data/sample_crtp_dependent.cu`:
  - CRTP base with a method whose return type depends on the derived type.
  - Function template whose return type depends on `T::value_type`.
  - A plain device function (`vec3_dot`) that must still be mangled normally.
- [x] New tests in `ast_canopy/tests/test_crtp_dependent_mangle.py`:
  - Parsing the CRTP header does not segfault.
  - Both `CRTPBase` and `Vec3` class templates are captured.
  - `extract_value` appears as a function template (dependent-signature path works).
  - `vec3_dot` still has a valid `_Z`-prefixed Itanium mangled name (regression guard).
- [x] Rebuilt `libastcanopy.so` with only this branch applied and ran the test to confirm the fix is sufficient in isolation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash when parsing template-dependent C++/CUDA signatures. Dependent return/parameter types and methods in dependent contexts are now handled safely; non-dependent functions continue to produce normal mangled names.

* **Tests**
  * Added tests and a CUDA sample exercising CRTP and dependent-signature parsing and mangling to verify correct handling and prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->