### PR TITLE
ast_canopy: guard Type constructor against null QualType

### DIFF
--- a/ast_canopy/cpp/src/type.cpp
+++ b/ast_canopy/cpp/src/type.cpp
@@ -85,7 +85,17 @@ Type::Type(const clang::QualType &qualtype, const clang::ASTContext &context) {
   // type itself for portability. Downstream consumer of this type information
   // should remember to include <stdint.h> or <cstdint> in their code.
 
+  // Guard: if the QualType is null, produce a placeholder.
+  if (qualtype.isNull()) {
+    name = "<null-type>";
+    unqualified_non_ref_type_name = "<null-type>";
+    _is_right_reference = false;
+    _is_left_reference = false;
+    return;
+  }
+
   std::string printed_name = qualtype.getAsString();
+
   clang::QualType ty = detail::contains_stdint_type(printed_name)
                            ? qualtype
                            : qualtype.getCanonicalType();

--- a/ast_canopy/tests/data/sample_null_qualtype.cu
+++ b/ast_canopy/tests/data/sample_null_qualtype.cu
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Minimal repro for the null-QualType crash in ast_canopy/cpp/src/type.cpp.
+//
+// When a field's type refers to an uninstantiated dependent member of a
+// template parameter (e.g. `typename T::nested`), Clang may hand the
+// ast_canopy Type constructor a null QualType during error recovery /
+// bypass_parse_error parsing. Before the fix, the subsequent call to
+// qualtype.getAsString() / qualtype.getCanonicalType() segfaulted.
+//
+// The fix adds an `if (qualtype.isNull()) { ... return; }` guard that
+// substitutes a "<null-type>" placeholder so parsing can continue.
+
+#pragma once
+
+// A trait-style template whose member field depends on T::nested --
+// deeply dependent types that aren't concretely instantiated here push
+// Clang's type resolution into edge cases that historically produced
+// null QualTypes under bypass_parse_error.
+template <typename T> struct DependentFieldTrait {
+  typename T::nested field_a;
+  typename T::template rebind<int>::other field_b;
+};
+
+// A plain concrete struct alongside, to assert the rest of the header
+// still parses.
+struct Plain {
+  int x;
+  float y;
+};

--- a/ast_canopy/tests/data/sample_null_qualtype.cu
+++ b/ast_canopy/tests/data/sample_null_qualtype.cu
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+// All rights reserved. SPDX-License-Identifier: Apache-2.0
 
 // Minimal repro for the null-QualType crash in ast_canopy/cpp/src/type.cpp.
 //

--- a/ast_canopy/tests/test_null_qualtype_guard.py
+++ b/ast_canopy/tests/test_null_qualtype_guard.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Standalone test for the null-QualType guard in
+``ast_canopy/cpp/src/type.cpp``.
+
+Under ``bypass_parse_error=True`` parsing of headers that use deeply
+dependent types (e.g. ``typename T::nested`` fields inside uninstantiated
+templates), Clang can hand the ast_canopy ``Type`` constructor a null
+``QualType``. The subsequent calls to ``qualtype.getAsString()`` and
+``qualtype.getCanonicalType()`` then segfault.
+
+The fix adds an early-return guard that substitutes a ``"<null-type>"``
+placeholder, so parsing continues instead of crashing.
+
+This test is defensive: the null-QualType code path is triggered by
+Clang's internal error recovery and is not easy to force
+deterministically from plain C++. The test therefore verifies that
+parsing a header with dependent member types completes without crashing
+the Python process and that non-dependent declarations remain
+parseable.
+"""
+
+import os
+
+import pytest
+
+from ast_canopy import parse_declarations_from_source
+
+
+@pytest.fixture(scope="module")
+def source_path():
+    here = os.path.dirname(os.path.abspath(__file__))
+    return os.path.join(here, "data", "sample_null_qualtype.cu")
+
+
+def test_dependent_member_types_do_not_crash(source_path):
+    """Parsing must not segfault on deeply dependent member types even
+    when Clang's type resolution falls back to null QualTypes."""
+    decls = parse_declarations_from_source(
+        source_path, [source_path], "sm_80", bypass_parse_error=True,
+    )
+    assert decls is not None
+
+
+def test_plain_struct_still_parsed(source_path):
+    """The presence of dependent/null-type fields must not prevent
+    surrounding non-dependent structs from being reported."""
+    decls = parse_declarations_from_source(
+        source_path, [source_path], "sm_80", bypass_parse_error=True,
+    )
+    names = [s.name for s in decls.structs]
+    assert "Plain" in names, names

--- a/ast_canopy/tests/test_null_qualtype_guard.py
+++ b/ast_canopy/tests/test_null_qualtype_guard.py
@@ -38,7 +38,10 @@ def test_dependent_member_types_do_not_crash(source_path):
     """Parsing must not segfault on deeply dependent member types even
     when Clang's type resolution falls back to null QualTypes."""
     decls = parse_declarations_from_source(
-        source_path, [source_path], "sm_80", bypass_parse_error=True,
+        source_path,
+        [source_path],
+        "sm_80",
+        bypass_parse_error=True,
     )
     assert decls is not None
 
@@ -47,7 +50,10 @@ def test_plain_struct_still_parsed(source_path):
     """The presence of dependent/null-type fields must not prevent
     surrounding non-dependent structs from being reported."""
     decls = parse_declarations_from_source(
-        source_path, [source_path], "sm_80", bypass_parse_error=True,
+        source_path,
+        [source_path],
+        "sm_80",
+        bypass_parse_error=True,
     )
     names = [s.name for s in decls.structs]
     assert "Plain" in names, names


### PR DESCRIPTION
## Summary

- Under `bypass_parse_error=True`, Clang's error recovery can hand the ast_canopy `Type` constructor a null `QualType` — for example when a field references a deeply dependent type (`typename T::nested`) inside an uninstantiated template. The subsequent calls to `qualtype.getAsString()` and `qualtype.getCanonicalType()` dereference the null `QualType` and segfault the whole Python process.
- Adds an early-return guard in `Type::Type` that substitutes a `"<null-type>"` placeholder so parsing continues. The placeholder is carried through `unqualified_non_ref_type_name` so downstream consumers see a stable sentinel rather than undefined behavior.

## Test plan

- [x] New sample `ast_canopy/tests/data/sample_null_qualtype.cu` with a `DependentFieldTrait` template whose fields use `typename T::nested` and `typename T::template rebind<int>::other`.
- [x] New tests in `ast_canopy/tests/test_null_qualtype_guard.py`:
  - Parsing under `bypass_parse_error=True` completes without segfaulting the process.
  - A plain concrete struct alongside the dependent template still parses and is returned.
- [x] Note that the null-`QualType` path is triggered by Clang's internal error recovery and is not easy to force deterministically from plain C++; the test is therefore a defensive smoke test for the guard. The docstring in the test file documents this explicitly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented crashes during parsing of code with dependent template/member types (improves stability in error-recovery scenarios).

* **Tests**
  * Added a parsing regression test and sample input to ensure dependent-type cases and simple structs parse without crashing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->