### PR TITLE
ast_canopy: guard Record against dependent/incomplete types

### DIFF
--- a/ast_canopy/ast_canopy/__init__.py
+++ b/ast_canopy/ast_canopy/__init__.py
@@ -5,11 +5,11 @@ import importlib.metadata
 
 __version__ = importlib.metadata.version("ast_canopy")
 
-from ast_canopy.pylibastcanopy import INVALID_ALIGN_OF, INVALID_SIZE_OF
 from ast_canopy.api import (
     parse_declarations_from_source,
     value_from_constexpr_vardecl,
 )
+from ast_canopy.constants import INVALID_ALIGN_OF, INVALID_SIZE_OF
 
 __all__ = [
     "__version__",

--- a/ast_canopy/ast_canopy/__init__.py
+++ b/ast_canopy/ast_canopy/__init__.py
@@ -5,6 +5,7 @@ import importlib.metadata
 
 __version__ = importlib.metadata.version("ast_canopy")
 
+from ast_canopy.pylibastcanopy import INVALID_ALIGN_OF, INVALID_SIZE_OF
 from ast_canopy.api import (
     parse_declarations_from_source,
     value_from_constexpr_vardecl,
@@ -12,6 +13,8 @@ from ast_canopy.api import (
 
 __all__ = [
     "__version__",
+    "INVALID_ALIGN_OF",
+    "INVALID_SIZE_OF",
     "parse_declarations_from_source",
     "value_from_constexpr_vardecl",
 ]

--- a/ast_canopy/ast_canopy/constants.py
+++ b/ast_canopy/ast_canopy/constants.py
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from ast_canopy.pylibastcanopy import INVALID_ALIGN_OF, INVALID_SIZE_OF
+
+__all__ = [
+    "INVALID_ALIGN_OF",
+    "INVALID_SIZE_OF",
+]

--- a/ast_canopy/ast_canopy/pylibastcanopy.cpp
+++ b/ast_canopy/ast_canopy/pylibastcanopy.cpp
@@ -15,6 +15,9 @@ using namespace ast_canopy;
 PYBIND11_MODULE(pylibastcanopy, m) {
   m.doc() = "Python bindings for canopy.hpp";
 
+  m.attr("INVALID_SIZE_OF") = py::int_(INVALID_SIZE_OF);
+  m.attr("INVALID_ALIGN_OF") = py::int_(INVALID_ALIGN_OF);
+
   py::register_exception<ParseError>(m, "ParseError");
 
   py::enum_<execution_space>(m, "execution_space")

--- a/ast_canopy/ast_canopy/pylibastcanopy.pyi
+++ b/ast_canopy/ast_canopy/pylibastcanopy.pyi
@@ -3,6 +3,9 @@ import typing
 from _typeshed import Incomplete
 from typing import ClassVar, overload
 
+INVALID_SIZE_OF: int
+INVALID_ALIGN_OF: int
+
 class ClassTemplate(Template):
     num_min_required_args: int
     qual_name: str

--- a/ast_canopy/cpp/include/ast_canopy/ast_canopy.hpp
+++ b/ast_canopy/cpp/include/ast_canopy/ast_canopy.hpp
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <cstddef>
+#include <limits>
 #include <optional>
 #include <set>
 #include <string>
@@ -19,6 +21,11 @@
 #include <ast_canopy/error.hpp>
 
 namespace ast_canopy {
+
+inline constexpr std::size_t INVALID_SIZE_OF =
+    std::numeric_limits<std::size_t>::max();
+inline constexpr std::size_t INVALID_ALIGN_OF =
+    std::numeric_limits<std::size_t>::max();
 
 struct TemplateParam;
 struct ClassTemplate;

--- a/ast_canopy/cpp/src/record.cpp
+++ b/ast_canopy/cpp/src/record.cpp
@@ -9,17 +9,12 @@
 #include <clang/AST/DeclCXX.h>
 
 #include <algorithm>
-#include <limits>
 
 #ifndef NDEBUG
 #include <iostream>
 #endif
 
 namespace ast_canopy {
-
-std::size_t constexpr INVALID_SIZE_OF = std::numeric_limits<std::size_t>::max();
-std::size_t constexpr INVALID_ALIGN_OF =
-    std::numeric_limits<std::size_t>::max();
 
 Record::Record(const clang::CXXRecordDecl *RD, RecordAncestor rp) {
   using AS = clang::AccessSpecifier;

--- a/ast_canopy/cpp/src/record.cpp
+++ b/ast_canopy/cpp/src/record.cpp
@@ -9,6 +9,7 @@
 #include <clang/AST/DeclCXX.h>
 
 #include <algorithm>
+#include <limits>
 
 #ifndef NDEBUG
 #include <iostream>
@@ -54,7 +55,12 @@ Record::Record(const clang::CXXRecordDecl *RD, RecordAncestor rp) {
     // Include all fields regardless of access specifier, downstream
     // tools needs all fields to create type with proper size and alignment.
     if (auto const *FD = clang::dyn_cast<clang::FieldDecl>(D)) {
-      fields.emplace_back(Field(FD, access));
+      try {
+        fields.emplace_back(Field(FD, access));
+      } catch (...) {
+        // Skip fields that cannot be processed (e.g. dependent types in
+        // uninstantiated templates).
+      }
     }
 
     // Skip Non-public function, nested class and template declarations
@@ -63,19 +69,36 @@ Record::Record(const clang::CXXRecordDecl *RD, RecordAncestor rp) {
       if (auto const *MD = clang::dyn_cast<clang::CXXMethodDecl>(D)) {
         if (MD->isImplicit())
           continue;
-        methods.emplace_back(Method(MD));
+        try {
+          methods.emplace_back(Method(MD));
+        } catch (...) {
+          // Skip methods that cannot be processed (e.g. methods with
+          // dependent types that cannot be mangled).
+        }
       }
 
       if (auto const *FTD = clang::dyn_cast<clang::FunctionTemplateDecl>(D)) {
-        templated_methods.emplace_back(FunctionTemplate(FTD));
+        try {
+          templated_methods.emplace_back(FunctionTemplate(FTD));
+        } catch (...) {
+          // Skip function templates that cannot be processed.
+        }
       }
 
       if (auto const *CTD = clang::dyn_cast<clang::ClassTemplateDecl>(D)) {
-        nested_class_templates.emplace_back(ClassTemplate(CTD));
+        try {
+          nested_class_templates.emplace_back(ClassTemplate(CTD));
+        } catch (...) {
+          // Skip nested class templates that cannot be processed.
+        }
       }
 
       if (auto const *R = clang::dyn_cast<clang::CXXRecordDecl>(D)) {
-        nested_records.emplace_back(Record(R, rp));
+        try {
+          nested_records.emplace_back(Record(R, rp));
+        } catch (...) {
+          // Skip nested records that cannot be processed.
+        }
       }
     }
   }
@@ -83,8 +106,16 @@ Record::Record(const clang::CXXRecordDecl *RD, RecordAncestor rp) {
   if (rp == RecordAncestor::ANCESTOR_IS_NOT_TEMPLATE) {
     clang::QualType type = RD->getASTContext().getTypeDeclType(RD);
     clang::ASTContext &ctx = RD->getASTContext();
-    sizeof_ = ctx.getTypeSize(type) / ctx.getCharWidth();
-    alignof_ = ctx.getTypeAlign(type) / ctx.getCharWidth();
+    // Guard against dependent or incomplete types whose layout cannot be
+    // computed.  This can happen for records inside class template
+    // specialisations that Clang has not fully instantiated.
+    if (!type->isDependentType() && !type->isIncompleteType()) {
+      sizeof_ = ctx.getTypeSize(type) / ctx.getCharWidth();
+      alignof_ = ctx.getTypeAlign(type) / ctx.getCharWidth();
+    } else {
+      sizeof_ = INVALID_SIZE_OF;
+      alignof_ = INVALID_ALIGN_OF;
+    }
   } else {
     // A record with class template parent is not instantiated, and thus
     // computing size and alignment of such a record is not possible.

--- a/ast_canopy/cpp/src/record.cpp
+++ b/ast_canopy/cpp/src/record.cpp
@@ -55,12 +55,7 @@ Record::Record(const clang::CXXRecordDecl *RD, RecordAncestor rp) {
     // Include all fields regardless of access specifier, downstream
     // tools needs all fields to create type with proper size and alignment.
     if (auto const *FD = clang::dyn_cast<clang::FieldDecl>(D)) {
-      try {
-        fields.emplace_back(Field(FD, access));
-      } catch (...) {
-        // Skip fields that cannot be processed (e.g. dependent types in
-        // uninstantiated templates).
-      }
+      fields.emplace_back(Field(FD, access));
     }
 
     // Skip Non-public function, nested class and template declarations
@@ -69,36 +64,19 @@ Record::Record(const clang::CXXRecordDecl *RD, RecordAncestor rp) {
       if (auto const *MD = clang::dyn_cast<clang::CXXMethodDecl>(D)) {
         if (MD->isImplicit())
           continue;
-        try {
-          methods.emplace_back(Method(MD));
-        } catch (...) {
-          // Skip methods that cannot be processed (e.g. methods with
-          // dependent types that cannot be mangled).
-        }
+        methods.emplace_back(Method(MD));
       }
 
       if (auto const *FTD = clang::dyn_cast<clang::FunctionTemplateDecl>(D)) {
-        try {
-          templated_methods.emplace_back(FunctionTemplate(FTD));
-        } catch (...) {
-          // Skip function templates that cannot be processed.
-        }
+        templated_methods.emplace_back(FunctionTemplate(FTD));
       }
 
       if (auto const *CTD = clang::dyn_cast<clang::ClassTemplateDecl>(D)) {
-        try {
-          nested_class_templates.emplace_back(ClassTemplate(CTD));
-        } catch (...) {
-          // Skip nested class templates that cannot be processed.
-        }
+        nested_class_templates.emplace_back(ClassTemplate(CTD));
       }
 
       if (auto const *R = clang::dyn_cast<clang::CXXRecordDecl>(D)) {
-        try {
-          nested_records.emplace_back(Record(R, rp));
-        } catch (...) {
-          // Skip nested records that cannot be processed.
-        }
+        nested_records.emplace_back(Record(R, rp));
       }
     }
   }

--- a/ast_canopy/tests/data/sample_record_incomplete.cu
+++ b/ast_canopy/tests/data/sample_record_incomplete.cu
@@ -10,8 +10,7 @@
 // still dependent or incomplete, Clang aborts inside getTypeSize.
 // The fix guards on isDependentType()/isIncompleteType() and emits
 // INVALID_SIZE_OF / INVALID_ALIGN_OF sentinels when layout cannot be
-// computed. Also adds a try/catch around per-field/-method construction
-// so a single bad child declaration does not lose the whole record.
+// computed.
 
 #pragma once
 

--- a/ast_canopy/tests/data/sample_record_incomplete.cu
+++ b/ast_canopy/tests/data/sample_record_incomplete.cu
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Minimal repro for the dependent/incomplete type crash in
+// ast_canopy/cpp/src/record.cpp.
+//
+// The Record constructor calls ctx.getTypeSize(type) /
+// ctx.getTypeAlign(type) on class template specialisations that reach
+// the matcher with ANCESTOR_IS_NOT_TEMPLATE. When the specialisation is
+// still dependent or incomplete, Clang aborts inside getTypeSize.
+// The fix guards on isDependentType()/isIncompleteType() and emits
+// INVALID_SIZE_OF / INVALID_ALIGN_OF sentinels when layout cannot be
+// computed. Also adds a try/catch around per-field/-method construction
+// so a single bad child declaration does not lose the whole record.
+
+#pragma once
+
+// A forward declaration: `Fwd<int>` becomes an incomplete
+// ClassTemplateSpecialization if anything forces it into the parsed AST.
+template <typename T> struct Fwd;
+
+// Wrapper that uses Fwd via pointer -- fine at C++ level but forces
+// Clang to produce an (incomplete) Fwd<int> specialization node.
+struct UsesIncomplete {
+  Fwd<int> *ptr;
+};
+
+// A complete template instantiation in the same header, to prove the
+// guard does not break the normal path.
+template <typename T> struct Complete {
+  T data;
+};
+
+struct UsesComplete {
+  Complete<float> c;
+};

--- a/ast_canopy/tests/data/sample_record_incomplete.cu
+++ b/ast_canopy/tests/data/sample_record_incomplete.cu
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+// All rights reserved. SPDX-License-Identifier: Apache-2.0
 
 // Minimal repro for the dependent/incomplete type crash in
 // ast_canopy/cpp/src/record.cpp.

--- a/ast_canopy/tests/test_record_incomplete.py
+++ b/ast_canopy/tests/test_record_incomplete.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Standalone test for the dependent/incomplete type guards in
+``ast_canopy/cpp/src/record.cpp``.
+
+Three related changes in this file:
+
+1. ``Record::Record`` calls ``ctx.getTypeSize`` / ``ctx.getTypeAlign``
+   on class template specialisations reaching the matcher with
+   ``ANCESTOR_IS_NOT_TEMPLATE``. If the specialisation is still
+   dependent or incomplete, Clang aborts inside the size query. The
+   fix guards with ``!type->isDependentType() &&
+   !type->isIncompleteType()`` and emits ``INVALID_SIZE_OF`` /
+   ``INVALID_ALIGN_OF`` sentinels when layout cannot be computed.
+
+2. Each per-child construction (``Field``, ``Method``,
+   ``FunctionTemplate``, nested ``ClassTemplate``, nested ``Record``)
+   is wrapped in ``try { ... } catch (...) { /* skip */ }`` so a
+   single bad child does not lose the entire parent record.
+
+3. Adds a ``<limits>`` include. ``INVALID_SIZE_OF`` /
+   ``INVALID_ALIGN_OF`` use ``std::numeric_limits``; the header was
+   transitively included in conda builds but missing in the manylinux
+   wheel container. This cannot be exercised from pytest (it is a
+   build-time concern); this file documents it for provenance.
+"""
+
+import os
+
+import pytest
+
+from ast_canopy import parse_declarations_from_source
+
+
+@pytest.fixture(scope="module")
+def source_path():
+    here = os.path.dirname(os.path.abspath(__file__))
+    return os.path.join(here, "data", "sample_record_incomplete.cu")
+
+
+def test_incomplete_specialization_does_not_abort(source_path):
+    """Header containing an incomplete class template specialisation
+    (Fwd<int>) must not abort the parse."""
+    decls = parse_declarations_from_source(
+        source_path, [source_path], "sm_80", bypass_parse_error=True,
+    )
+    assert decls is not None
+
+
+def test_wrapper_structs_parsed(source_path):
+    """UsesIncomplete and UsesComplete should both parse."""
+    decls = parse_declarations_from_source(
+        source_path, [source_path], "sm_80", bypass_parse_error=True,
+    )
+    names = [s.name for s in decls.structs]
+    assert "UsesIncomplete" in names, names
+    assert "UsesComplete" in names, names
+
+
+def test_complete_specialization_has_layout(source_path):
+    """The fix must not regress layout computation for complete
+    specialisations: Complete<float> still gets a valid sizeof_."""
+    decls = parse_declarations_from_source(
+        source_path, [source_path], "sm_80", bypass_parse_error=True,
+    )
+    complete_specs = [
+        cts
+        for cts in decls.class_template_specializations
+        if "Complete" in cts.qual_name
+    ]
+    assert complete_specs, "Complete<float> not in parsed specializations"
+    assert complete_specs[0].sizeof_ > 0, complete_specs[0].sizeof_

--- a/ast_canopy/tests/test_record_incomplete.py
+++ b/ast_canopy/tests/test_record_incomplete.py
@@ -26,7 +26,7 @@ import os
 import pytest
 
 from ast_canopy import parse_declarations_from_source
-from ast_canopy.constants import INVALID_SIZE_OF
+from ast_canopy.constants import INVALID_ALIGN_OF, INVALID_SIZE_OF
 
 
 @pytest.fixture(scope="module")
@@ -72,7 +72,7 @@ def test_complete_specialization_has_layout(source_path):
     complete_specs = [
         cts
         for cts in decls.class_template_specializations
-        if "Complete" in cts.qual_name
+        if cts.qual_name == "Complete<float>"
     ]
     assert complete_specs, "Complete<float> not in parsed specializations"
     assert complete_specs[0].sizeof_ > 0, complete_specs[0].sizeof_
@@ -95,3 +95,6 @@ def test_incomplete_specialization_has_sentinel_layout(source_path):
     assert incomplete_specs[0].sizeof_ == INVALID_SIZE_OF, incomplete_specs[
         0
     ].sizeof_
+    assert incomplete_specs[0].alignof_ == INVALID_ALIGN_OF, incomplete_specs[
+        0
+    ].alignof_

--- a/ast_canopy/tests/test_record_incomplete.py
+++ b/ast_canopy/tests/test_record_incomplete.py
@@ -21,12 +21,11 @@ Two related changes in this file:
    build-time concern); this file documents it for provenance.
 """
 
-import ctypes
 import os
 
 import pytest
 
-from ast_canopy import parse_declarations_from_source
+from ast_canopy import INVALID_SIZE_OF, parse_declarations_from_source
 
 
 @pytest.fixture(scope="module")
@@ -91,8 +90,7 @@ def test_incomplete_specialization_has_sentinel_layout(source_path):
         for cts in decls.class_template_specializations
         if cts.qual_name == "Fwd<int>"
     ]
-    invalid_sizeof = ctypes.c_size_t(-1).value
     assert incomplete_specs, "Fwd<int> not in parsed specializations"
-    assert incomplete_specs[0].sizeof_ == invalid_sizeof, incomplete_specs[
+    assert incomplete_specs[0].sizeof_ == INVALID_SIZE_OF, incomplete_specs[
         0
     ].sizeof_

--- a/ast_canopy/tests/test_record_incomplete.py
+++ b/ast_canopy/tests/test_record_incomplete.py
@@ -4,7 +4,7 @@
 """Standalone test for the dependent/incomplete type guards in
 ``ast_canopy/cpp/src/record.cpp``.
 
-Three related changes in this file:
+Two related changes in this file:
 
 1. ``Record::Record`` calls ``ctx.getTypeSize`` / ``ctx.getTypeAlign``
    on class template specialisations reaching the matcher with
@@ -14,12 +14,7 @@ Three related changes in this file:
    !type->isIncompleteType()`` and emits ``INVALID_SIZE_OF`` /
    ``INVALID_ALIGN_OF`` sentinels when layout cannot be computed.
 
-2. Each per-child construction (``Field``, ``Method``,
-   ``FunctionTemplate``, nested ``ClassTemplate``, nested ``Record``)
-   is wrapped in ``try { ... } catch (...) { /* skip */ }`` so a
-   single bad child does not lose the entire parent record.
-
-3. Adds a ``<limits>`` include. ``INVALID_SIZE_OF`` /
+2. Adds a ``<limits>`` include. ``INVALID_SIZE_OF`` /
    ``INVALID_ALIGN_OF`` use ``std::numeric_limits``; the header was
    transitively included in conda builds but missing in the manylinux
    wheel container. This cannot be exercised from pytest (it is a

--- a/ast_canopy/tests/test_record_incomplete.py
+++ b/ast_canopy/tests/test_record_incomplete.py
@@ -43,7 +43,10 @@ def test_incomplete_specialization_does_not_abort(source_path):
     """Header containing an incomplete class template specialisation
     (Fwd<int>) must not abort the parse."""
     decls = parse_declarations_from_source(
-        source_path, [source_path], "sm_80", bypass_parse_error=True,
+        source_path,
+        [source_path],
+        "sm_80",
+        bypass_parse_error=True,
     )
     assert decls is not None
 
@@ -51,7 +54,10 @@ def test_incomplete_specialization_does_not_abort(source_path):
 def test_wrapper_structs_parsed(source_path):
     """UsesIncomplete and UsesComplete should both parse."""
     decls = parse_declarations_from_source(
-        source_path, [source_path], "sm_80", bypass_parse_error=True,
+        source_path,
+        [source_path],
+        "sm_80",
+        bypass_parse_error=True,
     )
     names = [s.name for s in decls.structs]
     assert "UsesIncomplete" in names, names
@@ -62,7 +68,10 @@ def test_complete_specialization_has_layout(source_path):
     """The fix must not regress layout computation for complete
     specialisations: Complete<float> still gets a valid sizeof_."""
     decls = parse_declarations_from_source(
-        source_path, [source_path], "sm_80", bypass_parse_error=True,
+        source_path,
+        [source_path],
+        "sm_80",
+        bypass_parse_error=True,
     )
     complete_specs = [
         cts

--- a/ast_canopy/tests/test_record_incomplete.py
+++ b/ast_canopy/tests/test_record_incomplete.py
@@ -21,6 +21,7 @@ Two related changes in this file:
    build-time concern); this file documents it for provenance.
 """
 
+import ctypes
 import os
 
 import pytest
@@ -75,3 +76,23 @@ def test_complete_specialization_has_layout(source_path):
     ]
     assert complete_specs, "Complete<float> not in parsed specializations"
     assert complete_specs[0].sizeof_ > 0, complete_specs[0].sizeof_
+
+
+def test_incomplete_specialization_has_sentinel_layout(source_path):
+    """Incomplete specialisations should report the invalid layout sentinel."""
+    decls = parse_declarations_from_source(
+        source_path,
+        [source_path],
+        "sm_80",
+        bypass_parse_error=True,
+    )
+    incomplete_specs = [
+        cts
+        for cts in decls.class_template_specializations
+        if cts.qual_name == "Fwd<int>"
+    ]
+    invalid_sizeof = ctypes.c_size_t(-1).value
+    assert incomplete_specs, "Fwd<int> not in parsed specializations"
+    assert incomplete_specs[0].sizeof_ == invalid_sizeof, incomplete_specs[
+        0
+    ].sizeof_

--- a/ast_canopy/tests/test_record_incomplete.py
+++ b/ast_canopy/tests/test_record_incomplete.py
@@ -25,7 +25,8 @@ import os
 
 import pytest
 
-from ast_canopy import INVALID_SIZE_OF, parse_declarations_from_source
+from ast_canopy import parse_declarations_from_source
+from ast_canopy.constants import INVALID_SIZE_OF
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
## Summary

Two related changes in `ast_canopy/cpp/src/record.cpp` and the public bindings:

1. **Guard size/align computation.** `Record::Record` called `ctx.getTypeSize(type)` / `ctx.getTypeAlign(type)` on class template specializations reaching the matcher with `ANCESTOR_IS_NOT_TEMPLATE`. If the specialization is still dependent or incomplete, for example a forward-declared `Fwd<int>` referenced only by pointer, Clang can assert inside the size query and abort parsing. Guard with `!type->isDependentType() && !type->isIncompleteType()` and emit `INVALID_SIZE_OF` / `INVALID_ALIGN_OF` sentinels when layout cannot be computed.

2. **Expose layout sentinels to Python.** `INVALID_SIZE_OF` / `INVALID_ALIGN_OF` now live in the public C++ header, are exported through pybind, and are surfaced from `ast_canopy.constants` with type stubs. The package root re-exports the same constants through that module, so tests and downstream callers do not need to hand-craft `ctypes.c_size_t(-1).value`.

The broad per-child constructor `try`/`catch` wrappers were removed; the fix is limited to the Clang layout API precondition that triggers this crash. Follow-up diagnostics/logging work for unsafe Clang/LLVM API calls is tracked in #330.

## Test plan

- [x] New sample `ast_canopy/tests/data/sample_record_incomplete.cu`:
  - Forward-declared `Fwd<int>` used only by pointer (incomplete specialization).
  - Complete `Complete<float>` specialization alongside (positive regression check).
- [x] New tests in `ast_canopy/tests/test_record_incomplete.py`:
  - Header with incomplete specialization parses without aborting.
  - Both `UsesIncomplete` and `UsesComplete` are returned in the struct list.
  - `Fwd<int>` reports the exported `ast_canopy.constants.INVALID_SIZE_OF` and `ast_canopy.constants.INVALID_ALIGN_OF` sentinels.
  - `Complete<float>` is matched explicitly and still reports a valid positive `sizeof_` (no regression on layout computation).
- [x] Verified after removing the broad `try`/`catch` wrappers and exporting the sentinels:
  - `pixi run build-ast-canopy`
  - `pixi run pytest ast_canopy/tests/test_record_incomplete.py`
  - `pixi run python -c "from ast_canopy.constants import INVALID_SIZE_OF, INVALID_ALIGN_OF; print(INVALID_SIZE_OF, INVALID_ALIGN_OF)"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed parser stability when processing incomplete or dependent C++ template types. The system now gracefully handles code with forward-declared template specializations and accurately determines layout information only for fully-defined types, while appropriately marking incomplete types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->