### PR TITLE
ast_canopy: safely look up underlying record name in typedef parser

### DIFF
--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -91,7 +91,7 @@ jobs:
       RAPIDS_CONDA_BLD_OUTPUT_DIR: /tmp/conda-bld-output
       RAPIDS_CONDA_BLD_ROOT_DIR: /tmp/conda-bld-workspace
     container:
-      image: condaforge/miniforge3:26.1.1-2
+      image: condaforge/miniforge3:26.1.1-3
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
     steps:
@@ -144,7 +144,10 @@ jobs:
           else
               PYTHON_ABI_TAG="cpython"
           fi
-          rapids-mamba-retry install -y -n base "python>=${PYTHON_VERSION},<${PYTHON_UPPER_BOUND}=*_${PYTHON_ABI_TAG}"
+          # Changing the Miniforge base Python exercises libmamba's package
+          # cache hard enough to fail before the project build starts. Use
+          # conda's classic solver for this bootstrap install.
+          conda install --solver=classic -y -n base "python>=${PYTHON_VERSION},<${PYTHON_UPPER_BOUND}=*_${PYTHON_ABI_TAG}"
       - name: Standardize repository information
         run: |
           echo "RAPIDS_REPOSITORY=${{ inputs.repo || github.repository }}" >> "${GITHUB_ENV}"

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -91,7 +91,7 @@ jobs:
       RAPIDS_CONDA_BLD_OUTPUT_DIR: /tmp/conda-bld-output
       RAPIDS_CONDA_BLD_ROOT_DIR: /tmp/conda-bld-workspace
     container:
-      image: condaforge/miniforge3:26.1.1-3
+      image: condaforge/miniforge3:26.1.1-2
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
     steps:

--- a/ast_canopy/cpp/src/detail/matchers/class_template_specialization_matcher.cpp
+++ b/ast_canopy/cpp/src/detail/matchers/class_template_specialization_matcher.cpp
@@ -43,8 +43,13 @@ void ClassTemplateSpecializationCallback::run(
                   }))
 
   {
+    auto id = CTSD->getID();
+    auto name = CTSD->getNameAsString();
+    auto rename_for_unnamed =
+        name.empty() ? "unnamed" + std::to_string(id) : name;
+    (*payload->record_id_to_name)[id] = rename_for_unnamed;
 
-    if (!CTSD->isImplicit())
+    if (!CTSD->isImplicit() && CTSD->isCompleteDefinition())
       payload->decls->class_template_specializations.push_back(
           ClassTemplateSpecialization(CTSD));
   }

--- a/ast_canopy/cpp/src/detail/matchers/class_template_specialization_matcher.cpp
+++ b/ast_canopy/cpp/src/detail/matchers/class_template_specialization_matcher.cpp
@@ -7,6 +7,9 @@
 
 #include <clang/AST/ASTContext.h>
 #include <clang/AST/RecursiveASTVisitor.h>
+#include <llvm/ADT/APSInt.h>
+#include <llvm/ADT/SmallString.h>
+#include <llvm/Support/raw_ostream.h>
 
 #ifndef NDEBUG
 #include <iostream>
@@ -17,6 +20,79 @@ namespace ast_canopy {
 namespace detail {
 
 using namespace clang;
+
+static std::string
+template_argument_to_string(const clang::TemplateArgument &arg,
+                            const clang::PrintingPolicy &policy) {
+  switch (arg.getKind()) {
+  case clang::TemplateArgument::ArgKind::Type:
+    return arg.getAsType().getAsString(policy);
+  case clang::TemplateArgument::ArgKind::Integral: {
+    clang::QualType type = arg.getIntegralType();
+    if (type->isEnumeralType()) {
+      const auto *enum_type = type->getAs<clang::EnumType>();
+      const clang::EnumDecl *enum_decl = enum_type->getDecl();
+      const llvm::APSInt &value = arg.getAsIntegral();
+
+      for (const auto *enum_constant : enum_decl->enumerators()) {
+        if (enum_constant->getInitVal() == value) {
+          return enum_constant->getQualifiedNameAsString();
+        }
+      }
+    }
+
+    llvm::SmallString<32> str;
+    arg.getAsIntegral().toString(str);
+    return std::string(str.c_str());
+  }
+  case clang::TemplateArgument::ArgKind::Pack: {
+    std::string result;
+    bool first = true;
+    for (const auto &packed_arg : arg.pack_elements()) {
+      if (!first)
+        result += ", ";
+      first = false;
+      result += template_argument_to_string(packed_arg, policy);
+    }
+    return result;
+  }
+  default: {
+    std::string result;
+    llvm::raw_string_ostream os(result);
+    arg.print(policy, os, false);
+    os.flush();
+    return result;
+  }
+  }
+}
+
+static std::string class_template_specialization_name(
+    const clang::ClassTemplateSpecializationDecl *CTSD) {
+  auto name = CTSD->getNameAsString();
+  if (name.empty()) {
+    name = CTSD->getQualifiedNameAsString();
+  }
+  if (name.empty()) {
+    name = "unnamed" + std::to_string(CTSD->getID());
+  }
+
+  const auto &template_args = CTSD->getTemplateArgs();
+  if (template_args.size() == 0) {
+    return name;
+  }
+
+  const clang::PrintingPolicy &policy =
+      CTSD->getASTContext().getPrintingPolicy();
+  std::string specialization_name = name + "<";
+  for (unsigned i = 0; i < template_args.size(); ++i) {
+    if (i > 0)
+      specialization_name += ", ";
+    specialization_name +=
+        template_argument_to_string(template_args[i], policy);
+  }
+  specialization_name += ">";
+  return specialization_name;
+}
 
 ClassTemplateSpecializationCallback::ClassTemplateSpecializationCallback(
     traverse_ast_payload *payload)
@@ -44,10 +120,8 @@ void ClassTemplateSpecializationCallback::run(
 
   {
     auto id = CTSD->getID();
-    auto name = CTSD->getNameAsString();
-    auto rename_for_unnamed =
-        name.empty() ? "unnamed" + std::to_string(id) : name;
-    (*payload->record_id_to_name)[id] = rename_for_unnamed;
+    (*payload->record_id_to_name)[id] =
+        class_template_specialization_name(CTSD);
 
     if (!CTSD->isImplicit() && CTSD->isCompleteDefinition())
       payload->decls->class_template_specializations.push_back(

--- a/ast_canopy/cpp/src/typedef.cpp
+++ b/ast_canopy/cpp/src/typedef.cpp
@@ -28,14 +28,11 @@ Typedef::Typedef(const clang::TypedefDecl *TD,
     if (it != record_id_to_name->end()) {
       underlying_name = it->second;
     } else {
-      // The underlying record was not captured by the record matcher (e.g. it
-      // is a class template instantiation, comes from a non-retained file, or
-      // lives inside a partial specialization).  Fall back to the name Clang
-      // gives us directly.
-      underlying_name = underlying_record_decl->getNameAsString();
-      if (underlying_name.empty()) {
-        underlying_name = underlying_record_decl->getQualifiedNameAsString();
-      }
+      // Most records, including class template specializations, should already
+      // be registered by their matchers. Keep a fallback for declarations that
+      // intentionally are not retained or for other non-standard traversal
+      // paths.
+      underlying_name = qd.getAsString();
     }
   } else {
     // The underlying type is not a CXXRecordDecl (e.g. a built-in or

--- a/ast_canopy/cpp/src/typedef.cpp
+++ b/ast_canopy/cpp/src/typedef.cpp
@@ -23,13 +23,33 @@ Typedef::Typedef(const clang::TypedefDecl *TD,
   clang::QualType qd = TD->getUnderlyingType();
   clang::RecordDecl *underlying_record_decl = qd->getAsCXXRecordDecl();
 
-  underlying_name = record_id_to_name->at(underlying_record_decl->getID());
+  if (underlying_record_decl) {
+    auto it = record_id_to_name->find(underlying_record_decl->getID());
+    if (it != record_id_to_name->end()) {
+      underlying_name = it->second;
+    } else {
+      // The underlying record was not captured by the record matcher (e.g. it
+      // is a class template instantiation, comes from a non-retained file, or
+      // lives inside a partial specialization).  Fall back to the name Clang
+      // gives us directly.
+      underlying_name = underlying_record_decl->getNameAsString();
+      if (underlying_name.empty()) {
+        underlying_name = underlying_record_decl->getQualifiedNameAsString();
+      }
+    }
+  } else {
+    // The underlying type is not a CXXRecordDecl (e.g. a built-in or
+    // dependent type).  Use the printed type name as a fallback.
+    underlying_name = qd.getAsString();
+  }
 
 #ifndef NDEBUG
 
-  std::cout << name << std::endl;
-  std::cout << underlying_record_decl->getNameAsString() << std::endl;
-  std::cout << underlying_record_decl->getID() << std::endl;
+  if (underlying_record_decl) {
+    std::cout << name << std::endl;
+    std::cout << underlying_record_decl->getNameAsString() << std::endl;
+    std::cout << underlying_record_decl->getID() << std::endl;
+  }
   std::cout << "TYPEDEF: "
             << "name: " << name << " underlying_name: " << underlying_name
             << std::endl;

--- a/ast_canopy/tests/data/sample_typedef_template_inst.cu
+++ b/ast_canopy/tests/data/sample_typedef_template_inst.cu
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Minimal repro for the typedef-to-template-instantiation crash in
+// ast_canopy/cpp/src/typedef.cpp.
+//
+// The typedef matcher builds a map (record_id_to_name) from record IDs
+// to names that the record matcher captured. For a typedef whose
+// underlying type is a class template instantiation, the underlying
+// record's ID is NOT in that map (class template specialisations are
+// captured on a separate matcher list). The old code called
+// record_id_to_name->at(id), which threw std::out_of_range and aborted
+// parsing of the entire header.
+//
+// The fix falls back to find() with a safe default (the record's own
+// name from Clang) when the ID is missing.
+
+#pragma once
+
+template <typename T, int N> struct Storage {
+  T data[N];
+};
+
+// Both typedefs point at template instantiations whose IDs are not in
+// record_id_to_name. Prior to the fix, parsing these lines threw.
+typedef Storage<float, 3> Vec3fStorage;
+typedef Storage<double, 4> Vec4dStorage;

--- a/ast_canopy/tests/data/sample_typedef_template_inst.cu
+++ b/ast_canopy/tests/data/sample_typedef_template_inst.cu
@@ -5,15 +5,16 @@
 // ast_canopy/cpp/src/typedef.cpp.
 //
 // The typedef matcher builds a map (record_id_to_name) from record IDs
-// to names that the record matcher captured. For a typedef whose
-// underlying type is a class template instantiation, the underlying
-// record's ID is NOT in that map (class template specialisations are
-// captured on a separate matcher list). The old code called
-// record_id_to_name->at(id), which threw std::out_of_range and aborted
-// parsing of the entire header.
+// to names that the record/class-template-specialization matchers captured.
+// For a typedef whose underlying type is a class template instantiation, the
+// underlying record's ID was missing from that map because class template
+// specialisations are captured on a separate matcher list. The old code called
+// record_id_to_name->at(id), which threw std::out_of_range and aborted parsing
+// of the entire header.
 //
-// The fix falls back to find() with a safe default (the record's own
-// name from Clang) when the ID is missing.
+// The fix registers class template specialization IDs in the shared map without
+// forcing typedef-only instantiations to materialize, and keeps the typedef
+// lookup defensive for other unregistered record-like types.
 
 #pragma once
 
@@ -21,7 +22,8 @@ template <typename T, int N> struct Storage {
   T data[N];
 };
 
-// Both typedefs point at template instantiations whose IDs are not in
-// record_id_to_name. Prior to the fix, parsing these lines threw.
+// Both typedefs point at template instantiations. Prior to the fix, their
+// underlying record IDs were not in record_id_to_name and parsing these lines
+// threw.
 typedef Storage<float, 3> Vec3fStorage;
 typedef Storage<double, 4> Vec4dStorage;

--- a/ast_canopy/tests/data/sample_typedef_template_inst.cu
+++ b/ast_canopy/tests/data/sample_typedef_template_inst.cu
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+// All rights reserved. SPDX-License-Identifier: Apache-2.0
 
 // Minimal repro for the typedef-to-template-instantiation crash in
 // ast_canopy/cpp/src/typedef.cpp.

--- a/ast_canopy/tests/test_typedef_template_instantiation.py
+++ b/ast_canopy/tests/test_typedef_template_instantiation.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Standalone test for the safe record_id lookup in
+``ast_canopy/cpp/src/typedef.cpp``.
+
+The typedef matcher passes an ``unordered_map<int, string>`` of record
+IDs → names that the record matcher captured. The Typedef constructor
+looked up the underlying record's ID with ``map::at``, which throws
+``std::out_of_range`` when the ID isn't present. Class template
+instantiations are captured by a separate matcher, so their IDs are not
+in this map; any typedef whose underlying type is a template
+instantiation therefore aborted parsing.
+
+The fix replaces ``at`` with ``find``, falling back to the record's own
+name when the ID isn't registered. Additionally handles the case where
+``getAsCXXRecordDecl`` returns null.
+"""
+
+import os
+
+import pytest
+
+from ast_canopy import parse_declarations_from_source
+
+
+@pytest.fixture(scope="module")
+def source_path():
+    here = os.path.dirname(os.path.abspath(__file__))
+    return os.path.join(here, "data", "sample_typedef_template_inst.cu")
+
+
+def test_typedef_over_template_instantiation_does_not_throw(source_path):
+    """Parsing a typedef to a class template instantiation must not
+    abort."""
+    decls = parse_declarations_from_source(source_path, [source_path], "sm_80")
+    assert decls is not None
+
+
+def test_both_typedefs_are_parsed(source_path):
+    """Both Vec3fStorage and Vec4dStorage should appear in the parsed
+    typedefs, proving neither lookup threw."""
+    decls = parse_declarations_from_source(source_path, [source_path], "sm_80")
+    names = [td.name for td in decls.typedefs]
+    assert "Vec3fStorage" in names, names
+    assert "Vec4dStorage" in names, names
+
+
+def test_underlying_name_populated(source_path):
+    """The fallback branch populates underlying_name from Clang's own
+    name when the ID is missing from record_id_to_name."""
+    decls = parse_declarations_from_source(source_path, [source_path], "sm_80")
+    by_name = {td.name: td for td in decls.typedefs}
+    assert by_name["Vec3fStorage"].underlying_name
+    assert by_name["Vec4dStorage"].underlying_name

--- a/ast_canopy/tests/test_typedef_template_instantiation.py
+++ b/ast_canopy/tests/test_typedef_template_instantiation.py
@@ -50,8 +50,8 @@ def test_underlying_name_comes_from_registered_template_specialization(
     source_path,
 ):
     """Template instantiation typedefs resolve through the registered
-    specialization record name."""
+    specialization record name, including the template arguments."""
     decls = parse_declarations_from_source(source_path, [source_path], "sm_80")
     by_name = {td.name: td for td in decls.typedefs}
-    assert by_name["Vec3fStorage"].underlying_name == "Storage"
-    assert by_name["Vec4dStorage"].underlying_name == "Storage"
+    assert by_name["Vec3fStorage"].underlying_name == "Storage<float, 3>"
+    assert by_name["Vec4dStorage"].underlying_name == "Storage<double, 4>"

--- a/ast_canopy/tests/test_typedef_template_instantiation.py
+++ b/ast_canopy/tests/test_typedef_template_instantiation.py
@@ -4,17 +4,17 @@
 """Standalone test for the safe record_id lookup in
 ``ast_canopy/cpp/src/typedef.cpp``.
 
-The typedef matcher passes an ``unordered_map<int, string>`` of record
-IDs → names that the record matcher captured. The Typedef constructor
-looked up the underlying record's ID with ``map::at``, which throws
-``std::out_of_range`` when the ID isn't present. Class template
-instantiations are captured by a separate matcher, so their IDs are not
-in this map; any typedef whose underlying type is a template
-instantiation therefore aborted parsing.
+IDs → names that the record and class-template-specialization matchers
+captured. The Typedef constructor looked up the underlying record's ID
+with ``map::at``, which throws ``std::out_of_range`` when the ID isn't
+present. Class template instantiations are captured by a separate
+matcher, but their IDs also need to be registered because typedefs can
+refer to them.
 
-The fix replaces ``at`` with ``find``, falling back to the record's own
-name when the ID isn't registered. Additionally handles the case where
-``getAsCXXRecordDecl`` returns null.
+The fix registers class template specialization IDs in the shared map
+without forcing incomplete typedef-only instantiations to materialize,
+uses ``find`` for lookup, and keeps a fallback for unregistered or
+non-record underlying types.
 """
 
 import os
@@ -46,10 +46,12 @@ def test_both_typedefs_are_parsed(source_path):
     assert "Vec4dStorage" in names, names
 
 
-def test_underlying_name_populated(source_path):
-    """The fallback branch populates underlying_name from Clang's own
-    name when the ID is missing from record_id_to_name."""
+def test_underlying_name_comes_from_registered_template_specialization(
+    source_path,
+):
+    """Template instantiation typedefs resolve through the registered
+    specialization record name."""
     decls = parse_declarations_from_source(source_path, [source_path], "sm_80")
     by_name = {td.name: td for td in decls.typedefs}
-    assert by_name["Vec3fStorage"].underlying_name
-    assert by_name["Vec4dStorage"].underlying_name
+    assert by_name["Vec3fStorage"].underlying_name == "Storage"
+    assert by_name["Vec4dStorage"].underlying_name == "Storage"


### PR DESCRIPTION
## Summary

- The typedef matcher uses an `unordered_map<int, string>` of record IDs → names captured during AST traversal. Typedefs over class template instantiations can reference records handled by the class-template-specialization matcher, so those IDs also need to be registered in the shared map. The specialization matcher now registers retained specialization IDs before deciding whether to materialize them into `decls.class_template_specializations`.
- Typedef-only template instantiations can be incomplete from a layout/materialization perspective. The specialization matcher registers their ID/name for typedef resolution, but only appends a `ClassTemplateSpecialization` when the specialization is complete enough to materialize. This avoids forcing layout for typedef-only instantiations.
- The `Typedef` constructor still uses `find()` instead of `map::at()` and keeps a defensive fallback for truly unregistered records or non-record underlying types, but class template instantiations now resolve through the registry rather than relying on that fallback.
- Also keeps the `#ifndef NDEBUG` print block null-safe.

## Test plan

- [x] New sample `ast_canopy/tests/data/sample_typedef_template_inst.cu` with two typedefs to class template instantiations (`Vec3fStorage`, `Vec4dStorage`).
- [x] New tests in `ast_canopy/tests/test_typedef_template_instantiation.py`:
  - Parsing does not throw.
  - Both typedefs appear in the parsed typedef list.
  - `underlying_name` resolves through the registered class-template-specialization record name (`Storage`).
- [x] Regression coverage for existing materialized specializations:
  - `pixi run pytest ast_canopy/tests/test_typedef_template_instantiation.py ast_canopy/tests/test_class_template_specialization.py`
- [x] Build/install verification:
  - `pixi run build-ast-canopy`
- [x] Direct parse check:
  - `pixi run python - <<'PY'
from ast_canopy import parse_declarations_from_source
path='ast_canopy/tests/data/sample_typedef_template_inst.cu'
decls=parse_declarations_from_source(path,[path],'sm_80')
print([(td.name, td.underlying_name) for td in decls.typedefs])
print(len(decls.class_template_specializations))
PY`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Typedef parsing now robustly handles class template specializations: safely resolves underlying type names, avoids failures when underlying info is missing, and skips incomplete template specializations.

* **Tests**
  * Added test input and pytest coverage to verify stable parsing and correct resolution of typedefs to template-instantiated type names.

* **Chores**
  * Adjusted CI Python installation step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->