### PR TITLE
ast_canopy: handle unsupported template argument kinds without throwing

### DIFF
--- a/ast_canopy/ast_canopy/pylibastcanopy.cpp
+++ b/ast_canopy/ast_canopy/pylibastcanopy.cpp
@@ -144,12 +144,12 @@ PYBIND11_MODULE(pylibastcanopy, m) {
             return py::make_tuple(t.name, t.kind, t.type, t.is_pack);
           },
           [](py::tuple t) {
-            if (t.size() != 3 && t.size() != 4)
+            if (t.size() != 4)
               throw std::runtime_error(
                   "Invalid template param state during unpickle!");
-            return TemplateParam{
-                t[0].cast<std::string>(), t[1].cast<template_param_kind>(),
-                t[2].cast<Type>(), t.size() == 4 ? t[3].cast<bool>() : false};
+            return TemplateParam{t[0].cast<std::string>(),
+                                 t[1].cast<template_param_kind>(),
+                                 t[2].cast<Type>(), t[3].cast<bool>()};
           }));
 
   py::class_<Function>(m, "Function")

--- a/ast_canopy/ast_canopy/pylibastcanopy.cpp
+++ b/ast_canopy/ast_canopy/pylibastcanopy.cpp
@@ -134,21 +134,22 @@ PYBIND11_MODULE(pylibastcanopy, m) {
       .def_readwrite("name", &TemplateParam::name)
       .def_readwrite("type_", &TemplateParam::type)
       .def_readwrite("kind", &TemplateParam::kind)
+      .def_readwrite("is_pack", &TemplateParam::is_pack)
       .def("__repr__",
            [](const TemplateParam &t) {
              return "<TemplateParam: " + t.name + " " + t.type.name + ">";
            })
       .def(py::pickle(
           [](const TemplateParam &t) {
-            return py::make_tuple(t.name, t.kind, t.type);
+            return py::make_tuple(t.name, t.kind, t.type, t.is_pack);
           },
           [](py::tuple t) {
-            if (t.size() != 3)
+            if (t.size() != 3 && t.size() != 4)
               throw std::runtime_error(
                   "Invalid template param state during unpickle!");
-            return TemplateParam{t[0].cast<std::string>(),
-                                 t[1].cast<template_param_kind>(),
-                                 t[2].cast<Type>()};
+            return TemplateParam{
+                t[0].cast<std::string>(), t[1].cast<template_param_kind>(),
+                t[2].cast<Type>(), t.size() == 4 ? t[3].cast<bool>() : false};
           }));
 
   py::class_<Function>(m, "Function")

--- a/ast_canopy/ast_canopy/pylibastcanopy.pyi
+++ b/ast_canopy/ast_canopy/pylibastcanopy.pyi
@@ -96,6 +96,7 @@ class Template:
     ) -> None: ...
 
 class TemplateParam:
+    is_pack: bool
     kind: template_param_kind
     name: str
     type_: Type

--- a/ast_canopy/cpp/include/ast_canopy/ast_canopy.hpp
+++ b/ast_canopy/cpp/include/ast_canopy/ast_canopy.hpp
@@ -115,8 +115,9 @@ struct Template {
 };
 
 struct TemplateParam {
-  TemplateParam(const std::string &name, template_param_kind kind, Type type)
-      : name(name), kind(kind), type(type) {}
+  TemplateParam(const std::string &name, template_param_kind kind, Type type,
+                bool is_pack = false)
+      : name(name), kind(kind), type(type), is_pack(is_pack) {}
   TemplateParam(const clang::TemplateTypeParmDecl *);
   TemplateParam(const clang::NonTypeTemplateParmDecl *);
   TemplateParam(const clang::TemplateTemplateParmDecl *);
@@ -124,6 +125,7 @@ struct TemplateParam {
   std::string name;
   template_param_kind kind;
   Type type;
+  bool is_pack;
 };
 
 struct Function {

--- a/ast_canopy/cpp/src/class_template_specialization.cpp
+++ b/ast_canopy/cpp/src/class_template_specialization.cpp
@@ -21,7 +21,7 @@ ClassTemplateSpecialization::ClassTemplateSpecialization(
   const auto &tparam_list = CTSD->getTemplateArgs();
   actual_template_arguments.reserve(tparam_list.size());
 
-  for (auto i = 0; i < tparam_list.size(); i++) {
+  for (unsigned i = 0; i < tparam_list.size(); i++) {
     const auto &targ = tparam_list[i];
 
     clang::TemplateArgument::ArgKind kind = targ.getKind();
@@ -70,7 +70,12 @@ ClassTemplateSpecialization::ClassTemplateSpecialization(
       break;
     }
     default:
-      throw std::runtime_error("Unsupported template argument kind");
+      // Gracefully handle template argument kinds we don't yet support
+      // (e.g. Pack, Template, Expression, NullPtr, StructuralValue).
+      // Use a placeholder string so downstream code still sees the right
+      // number of arguments.
+      actual_template_arguments.push_back("<unsupported>");
+      break;
     }
   }
 }

--- a/ast_canopy/cpp/src/class_template_specialization.cpp
+++ b/ast_canopy/cpp/src/class_template_specialization.cpp
@@ -7,9 +7,56 @@
 
 #include <clang/AST/DeclTemplate.h>
 #include <llvm/ADT/APSInt.h>
-#include <llvm/Support/raw_ostream.h>
+#include <llvm/ADT/SmallString.h>
 
 namespace ast_canopy {
+
+static std::string
+integral_template_argument_to_string(const clang::TemplateArgument &targ) {
+  clang::QualType T = targ.getIntegralType();
+
+  if (T->isEnumeralType()) {
+    const auto *ET = T->getAs<clang::EnumType>();
+    const clang::EnumDecl *ED = ET->getDecl();
+    const llvm::APSInt &Val = targ.getAsIntegral();
+
+    for (const auto *ECD : ED->enumerators()) {
+      if (ECD->getInitVal() == Val) {
+        return ECD->getQualifiedNameAsString();
+      }
+    }
+  }
+
+  llvm::APSInt integer = targ.getAsIntegral();
+  llvm::SmallString<32> str; // -uint64_t::max() is 21 digits (with sign).
+  integer.toString(str);
+  return std::string(str.c_str());
+}
+
+static std::string
+template_argument_to_string(const clang::TemplateArgument &targ) {
+  switch (targ.getKind()) {
+  case clang::TemplateArgument::ArgKind::Type:
+    return targ.getAsType().getAsString();
+  case clang::TemplateArgument::ArgKind::Integral:
+    return integral_template_argument_to_string(targ);
+  case clang::TemplateArgument::ArgKind::Pack: {
+    std::string result;
+    bool first = true;
+    for (const auto &packed_arg : targ.pack_elements()) {
+      if (!first)
+        result += ", ";
+      first = false;
+      result += template_argument_to_string(packed_arg);
+    }
+    return result;
+  }
+  default:
+    // Gracefully handle template argument kinds we don't yet support
+    // (e.g. Template, Expression, NullPtr, StructuralValue).
+    return "<unsupported>";
+  }
+}
 
 ClassTemplateSpecialization::ClassTemplateSpecialization(
     const clang::ClassTemplateSpecializationDecl *CTSD)
@@ -23,60 +70,7 @@ ClassTemplateSpecialization::ClassTemplateSpecialization(
 
   for (unsigned i = 0; i < tparam_list.size(); i++) {
     const auto &targ = tparam_list[i];
-
-    clang::TemplateArgument::ArgKind kind = targ.getKind();
-    switch (kind) {
-    case clang::TemplateArgument::ArgKind::Type:
-      actual_template_arguments.push_back(targ.getAsType().getAsString());
-      break;
-    case clang::TemplateArgument::ArgKind::Integral: {
-      clang::QualType T = targ.getIntegralType();
-
-      // If this integral NTTP is actually an enum, try to recover the
-      // enumerator name from the value.
-      if (T->isEnumeralType()) {
-        const auto *ET = T->getAs<clang::EnumType>();
-        const clang::EnumDecl *ED = ET->getDecl();
-        const llvm::APSInt &Val = targ.getAsIntegral();
-
-        const clang::EnumConstantDecl *Matched = nullptr;
-        for (const auto *ECD : ED->enumerators()) {
-          if (ECD->getInitVal() == Val) {
-            Matched = ECD;
-            break;
-          }
-        }
-
-        if (Matched) {
-          // Use the fully-qualified enumerator name if you like,
-          // or just ECD->getNameAsString() for the bare name.
-          actual_template_arguments.push_back(
-              Matched->getQualifiedNameAsString());
-        } else {
-          // No enumerator found with that value; fall back to integer.
-          llvm::APSInt integer = Val;
-          llvm::SmallString<32> str;
-          integer.toString(str);
-          actual_template_arguments.push_back(str.c_str());
-        }
-      } else {
-        // Plain integral (not an enum type) — keep your existing behavior.
-        llvm::APSInt integer = targ.getAsIntegral();
-        llvm::SmallString<32> str; // -uint64_t::max() is 21 digits (with sign).
-        integer.toString(str);
-        actual_template_arguments.push_back(str.c_str());
-      }
-
-      break;
-    }
-    default:
-      // Gracefully handle template argument kinds we don't yet support
-      // (e.g. Pack, Template, Expression, NullPtr, StructuralValue).
-      // Use a placeholder string so downstream code still sees the right
-      // number of arguments.
-      actual_template_arguments.push_back("<unsupported>");
-      break;
-    }
+    actual_template_arguments.push_back(template_argument_to_string(targ));
   }
 }
 

--- a/ast_canopy/cpp/src/template_param.cpp
+++ b/ast_canopy/cpp/src/template_param.cpp
@@ -29,6 +29,7 @@ TemplateParam::TemplateParam(const clang::TemplateTemplateParmDecl *TPD) {
   kind = template_param_kind::template_;
   // Leave type default-constructed -- a template template parameter does not
   // have a single associated type.
+  is_pack = TPD->isParameterPack();
 }
 
 } // namespace ast_canopy

--- a/ast_canopy/cpp/src/template_param.cpp
+++ b/ast_canopy/cpp/src/template_param.cpp
@@ -14,12 +14,14 @@ TemplateParam::TemplateParam(const clang::TemplateTypeParmDecl *TPD) {
   name = TPD->getNameAsString();
   type = Type(TPD->getASTContext().getTypeDeclType(TPD), TPD->getASTContext());
   kind = template_param_kind::type;
+  is_pack = TPD->isParameterPack();
 }
 
 TemplateParam::TemplateParam(const clang::NonTypeTemplateParmDecl *TPD) {
   name = TPD->getNameAsString();
   type = Type(TPD->getType(), TPD->getASTContext());
   kind = template_param_kind::non_type;
+  is_pack = TPD->isParameterPack();
 }
 
 TemplateParam::TemplateParam(const clang::TemplateTemplateParmDecl *TPD) {

--- a/ast_canopy/tests/data/sample_unsupported_template_args.cu
+++ b/ast_canopy/tests/data/sample_unsupported_template_args.cu
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+// All rights reserved. SPDX-License-Identifier: Apache-2.0
 
 // Minimal repro for the "Unsupported template argument kind" throw in
 // class_template_specialization.cpp.

--- a/ast_canopy/tests/data/sample_unsupported_template_args.cu
+++ b/ast_canopy/tests/data/sample_unsupported_template_args.cu
@@ -1,14 +1,14 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 // All rights reserved. SPDX-License-Identifier: Apache-2.0
 
-// Minimal repro for the "Unsupported template argument kind" throw in
+// Minimal repro for handling Pack-kind template arguments in
 // class_template_specialization.cpp.
 //
 // Parameter packs instantiate to a Pack-kind TemplateArgument on the
 // specialization's getTemplateArgs() list. Prior to the fix, only Type
 // and Integral kinds were handled, so any specialization that contained
-// a Pack, Declaration, Template, Expression, etc. argument caused a
-// std::runtime_error to propagate and abort parsing of the whole header.
+// a Pack argument caused a std::runtime_error to propagate and abort parsing
+// of the whole header.
 
 #pragma once
 

--- a/ast_canopy/tests/data/sample_unsupported_template_args.cu
+++ b/ast_canopy/tests/data/sample_unsupported_template_args.cu
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Minimal repro for the "Unsupported template argument kind" throw in
+// class_template_specialization.cpp.
+//
+// Parameter packs instantiate to a Pack-kind TemplateArgument on the
+// specialization's getTemplateArgs() list. Prior to the fix, only Type
+// and Integral kinds were handled, so any specialization that contained
+// a Pack, Declaration, Template, Expression, etc. argument caused a
+// std::runtime_error to propagate and abort parsing of the whole header.
+
+#pragma once
+
+// Variadic template -- instantiations produce a Pack-kind template
+// argument that the old code did not handle.
+template <typename... Ts> struct Variadic {
+  static constexpr int count = sizeof...(Ts);
+};
+
+// Force an instantiation so a ClassTemplateSpecializationDecl exists
+// in the parsed AST.
+struct ForceInstantiation {
+  Variadic<int, float, double> v;
+};
+
+// A plain, fully-supported specialization should still be parsed.
+template <typename T, int N> struct Simple {
+  T data[N];
+};
+
+struct ForceSimple {
+  Simple<float, 3> s;
+};

--- a/ast_canopy/tests/data/sample_unsupported_template_args.cu
+++ b/ast_canopy/tests/data/sample_unsupported_template_args.cu
@@ -32,3 +32,16 @@ template <typename T, int N> struct Simple {
 struct ForceSimple {
   Simple<float, 3> s;
 };
+
+// A template-template parameter pack should be represented as a template
+// parameter with is_pack set, rather than throwing during template parsing.
+template <typename T> struct Box {
+  T value;
+};
+
+template <template <typename> class... Containers>
+struct TemplateTemplatePack {};
+
+struct ForceTemplateTemplatePack {
+  TemplateTemplatePack<Box> pack;
+};

--- a/ast_canopy/tests/test_unsupported_template_args.py
+++ b/ast_canopy/tests/test_unsupported_template_args.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Standalone test for the unsupported-template-argument fix in
+``ast_canopy/cpp/src/class_template_specialization.cpp``.
+
+The class template specialization constructor previously threw
+``std::runtime_error("Unsupported template argument kind")`` when it saw
+any ``TemplateArgument::ArgKind`` other than ``Type`` or ``Integral``.
+Parameter packs, for example, produce a ``Pack``-kind argument on the
+specialization's argument list, which caused the whole parse to abort.
+
+The fix substitutes a ``"<unsupported>"`` placeholder string so parsing
+continues.
+"""
+
+import os
+
+import pytest
+
+from ast_canopy import parse_declarations_from_source
+
+
+@pytest.fixture(scope="module")
+def source_path():
+    here = os.path.dirname(os.path.abspath(__file__))
+    return os.path.join(here, "data", "sample_unsupported_template_args.cu")
+
+
+def test_pack_specialization_does_not_throw(source_path):
+    """A specialization with a parameter-pack argument must not abort the
+    parse."""
+    decls = parse_declarations_from_source(source_path, [source_path], "sm_80")
+    assert decls is not None
+
+
+def test_supported_specialization_still_parsed(source_path):
+    """The presence of an unsupported-kind specialization must not prevent
+    other, fully-supported specializations in the same header from being
+    parsed."""
+    decls = parse_declarations_from_source(source_path, [source_path], "sm_80")
+    cts_names = [cts.qual_name for cts in decls.class_template_specializations]
+    assert any("Simple" in n for n in cts_names), cts_names
+
+
+def test_unsupported_pack_has_placeholder_argument(source_path):
+    """For the Variadic<int, float, double> specialization, the pack
+    argument should be represented by a placeholder string rather than
+    having thrown."""
+    decls = parse_declarations_from_source(source_path, [source_path], "sm_80")
+    variadic = [
+        cts
+        for cts in decls.class_template_specializations
+        if "Variadic" in cts.qual_name
+    ]
+    assert variadic, "Variadic specialization missing from parsed decls"
+    args = variadic[0].actual_template_arguments
+    assert "<unsupported>" in args, args

--- a/ast_canopy/tests/test_unsupported_template_args.py
+++ b/ast_canopy/tests/test_unsupported_template_args.py
@@ -20,6 +20,7 @@ import os
 import pytest
 
 from ast_canopy import parse_declarations_from_source
+from ast_canopy.pylibastcanopy import template_param_kind
 
 
 @pytest.fixture(scope="module")
@@ -69,6 +70,25 @@ def test_variadic_template_parameter_is_marked_as_pack(source_path):
     params = variadic_templates[0].template_parameters
     assert len(params) == 1
     assert params[0].name == "Ts"
+    assert params[0].is_pack
+
+
+def test_template_template_parameter_pack_is_marked_as_pack(source_path):
+    """Template-template parameter packs should be represented with
+    template kind and pack metadata."""
+    decls = parse_declarations_from_source(source_path, [source_path], "sm_80")
+    template_template_packs = [
+        ct
+        for ct in decls.class_templates
+        if ct.qual_name == "TemplateTemplatePack"
+    ]
+    assert len(template_template_packs) == 1, [
+        ct.qual_name for ct in decls.class_templates
+    ]
+    params = template_template_packs[0].template_parameters
+    assert len(params) == 1
+    assert params[0].name == "Containers"
+    assert params[0].kind == template_param_kind.template_
     assert params[0].is_pack
 
 

--- a/ast_canopy/tests/test_unsupported_template_args.py
+++ b/ast_canopy/tests/test_unsupported_template_args.py
@@ -10,8 +10,9 @@ any ``TemplateArgument::ArgKind`` other than ``Type`` or ``Integral``.
 Parameter packs, for example, produce a ``Pack``-kind argument on the
 specialization's argument list, which caused the whole parse to abort.
 
-The fix substitutes a ``"<unsupported>"`` placeholder string so parsing
-continues.
+The fix records whether a declared template parameter is a pack and
+prints ``Pack``-kind specialization arguments by joining their elements,
+so parsing continues without losing the actual packed argument list.
 """
 
 import os
@@ -27,6 +28,18 @@ def source_path():
     return os.path.join(here, "data", "sample_unsupported_template_args.cu")
 
 
+def _find_specialization(decls, qual_name):
+    matches = [
+        cts
+        for cts in decls.class_template_specializations
+        if cts.qual_name == qual_name
+    ]
+    assert len(matches) == 1, [
+        cts.qual_name for cts in decls.class_template_specializations
+    ]
+    return matches[0]
+
+
 def test_pack_specialization_does_not_throw(source_path):
     """A specialization with a parameter-pack argument must not abort the
     parse."""
@@ -40,19 +53,30 @@ def test_supported_specialization_still_parsed(source_path):
     parsed."""
     decls = parse_declarations_from_source(source_path, [source_path], "sm_80")
     cts_names = [cts.qual_name for cts in decls.class_template_specializations]
-    assert any("Simple" in n for n in cts_names), cts_names
+    assert "Simple<float, 3>" in cts_names, cts_names
 
 
-def test_unsupported_pack_has_placeholder_argument(source_path):
-    """For the Variadic<int, float, double> specialization, the pack
-    argument should be represented by a placeholder string rather than
-    having thrown."""
+def test_variadic_template_parameter_is_marked_as_pack(source_path):
+    """The Variadic template's single declared parameter should be
+    represented as a type template parameter pack."""
     decls = parse_declarations_from_source(source_path, [source_path], "sm_80")
-    variadic = [
-        cts
-        for cts in decls.class_template_specializations
-        if "Variadic" in cts.qual_name
+    variadic_templates = [
+        ct for ct in decls.class_templates if ct.qual_name == "Variadic"
     ]
-    assert variadic, "Variadic specialization missing from parsed decls"
-    args = variadic[0].actual_template_arguments
-    assert "<unsupported>" in args, args
+    assert len(variadic_templates) == 1, [
+        ct.qual_name for ct in decls.class_templates
+    ]
+    params = variadic_templates[0].template_parameters
+    assert len(params) == 1
+    assert params[0].name == "Ts"
+    assert params[0].is_pack
+
+
+def test_pack_argument_is_expanded(source_path):
+    """For the Variadic<int, float, double> specialization, the pack
+    argument should preserve the packed argument list rather than using
+    an unsupported placeholder."""
+    decls = parse_declarations_from_source(source_path, [source_path], "sm_80")
+    variadic = _find_specialization(decls, "Variadic<int, float, double>")
+    args = variadic.actual_template_arguments
+    assert args == ["int, float, double"]


### PR DESCRIPTION
## Summary

- The `ClassTemplateSpecialization` constructor previously threw `std::runtime_error("Unsupported template argument kind")` whenever it encountered a `TemplateArgument` of any kind other than `Type` or `Integral`. In practice this means that a header containing e.g. a variadic template instantiation (which produces a `Pack`-kind argument on the specialization's argument list) aborts parsing entirely.
- Handles the remaining kinds (`Pack`, `Template`, `Expression`, `NullPtr`, `Declaration`, `StructuralValue`, `TemplateExpansion`) by emitting a `"<unsupported>"` placeholder string. Downstream code still sees the right number of arguments and can decide whether the specialization is actually usable, rather than having the whole parse aborted.
- Also fixes a signedness warning on the loop index (`auto i` → `unsigned i`).

## Test plan

- [x] New sample `ast_canopy/tests/data/sample_unsupported_template_args.cu` with a `Variadic<int, float, double>` instantiation (Pack-kind arg) and a fully-supported `Simple<float, 3>` specialization alongside.
- [x] New tests in `ast_canopy/tests/test_unsupported_template_args.py`:
  - Pack-arg specialization does not abort the parse.
  - The fully-supported `Simple<float, 3>` specialization is still returned.
  - The pack argument is represented as `"<unsupported>"` in `actual_template_arguments`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Template parameter metadata now exposes whether a parameter is a pack (is_pack) in APIs, Python bindings and type stubs; Python pickle format updated to include is_pack.

* **Bug Fixes**
  * Template-argument formatting now expands parameter-pack arguments and uses a safe "<unsupported>" placeholder for unknown kinds instead of failing.

* **Tests**
  * Added tests exercising parsing of class template specializations, including pack-containing cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->