### PR TITLE
Document recent ast_canopy updates

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -42,6 +42,7 @@ numbast
    :recursive:
 
    static
+   types
    tools
 
 numbast.static

--- a/docs/source/dynamic.rst
+++ b/docs/source/dynamic.rst
@@ -119,6 +119,22 @@ Use ``numbast.types.register_cxx_type`` when a function or method signature
 mentions a C++ type that ast_canopy did not parse, but you already know the
 Numba type that should represent it.
 
+The ``cxx_name`` argument should match the type string Numbast receives from
+ast_canopy for a signature, usually ``Type.unqualified_non_ref_type_name`` from
+a parameter or return type. For namespaced types this normally includes the
+C++ namespace qualification, such as ``third_party::Handle``. It is not the
+Python API name, and it is not necessarily a declaration's ``qual_name``.
+
+When in doubt, inspect the parsed declaration before registering the mapping:
+
+.. code-block:: python
+
+  for param in decls.functions[0].params:
+      print(param.type_.unqualified_non_ref_type_name)
+
+Top-level ``const`` and reference qualifiers are stripped from this lookup key;
+pointer types are resolved by looking up their pointee type.
+
 .. code-block:: python
 
   from numba import types as nbtypes

--- a/docs/source/dynamic.rst
+++ b/docs/source/dynamic.rst
@@ -90,6 +90,42 @@ Numbast can generate and use bindings at runtime:
   kernel[1, 1](arr)
   np.testing.assert_allclose(arr, [3.0, np.sqrt(3.0)], rtol=1e-2)
 
+Struct name overrides
+---------------------
+
+``bind_cxx_struct`` accepts a ``name=`` keyword for cases where the parsed record
+name is not the C++ type spelling that should appear in generated shim code and
+Numba's type registry. This is useful when binding a concrete class-template
+specialization through the lower-level struct API.
+
+.. code-block:: python
+
+  matrix = next(
+      s
+      for s in decls.class_template_specializations
+      if s.qual_name == "Eigen::Matrix<float, 3, 1>"
+  )
+
+  Matrix3f = bind_cxx_struct(
+      shim_writer,
+      matrix,
+      name="Eigen::Matrix<float, 3, 1>",
+  )
+
+External C++ type mappings
+--------------------------
+
+Use ``numbast.types.register_cxx_type`` when a function or method signature
+mentions a C++ type that ast_canopy did not parse, but you already know the
+Numba type that should represent it.
+
+.. code-block:: python
+
+  from numba import types as nbtypes
+  from numbast.types import register_cxx_type
+
+  register_cxx_type("third_party::Handle", nbtypes.uint64)
+
 Class template calls
 --------------------
 

--- a/docs/source/supported_declarations.rst
+++ b/docs/source/supported_declarations.rst
@@ -9,12 +9,19 @@ Concrete structs and classes
 - Constructors generate typing and lowering for instantiation
 - Conversion operators are mapped to Python conversions
 - Public fields are exposed for read access
+- Records expose ``sizeof_`` and ``alignof_`` when Clang can compute a concrete
+  layout. For dependent or incomplete records, ast_canopy uses the exported
+  ``ast_canopy.INVALID_SIZE_OF`` and ``ast_canopy.INVALID_ALIGN_OF`` sentinels.
 
 Functions and operators
 -----------------------
 
 - Free functions receive typing and lowering for all overloads
 - Operator overloads are mapped to Python operators (e.g., ``operator+`` → ``operator.add``)
+- ``Function.mangled_name`` is an Itanium mangled symbol for resolved function
+  signatures. If a function has a template-dependent signature, ast_canopy
+  stores a deterministic fallback identifier instead; that fallback is useful
+  for distinguishing overloads but is not an ABI symbol.
 
 Templates
 ---------
@@ -24,6 +31,15 @@ Templates
 - Function templates (e.g., ``template<typename T> T add(T, T)``) are serialized with parameter lists
   and signatures so consumers can materialize concrete overloads.
 - Where present, explicit specializations and explicit instantiations are captured as distinct declarations.
+- Template parameters expose ``kind`` and ``is_pack`` metadata. ``kind`` may be
+  ``type_``, ``non_type``, or ``template_`` for template-template parameters.
+  ``is_pack`` is true for parameter packs such as ``typename... Ts`` or
+  ``template <typename> class... Containers``.
+- ``ClassTemplateSpecialization.actual_template_arguments`` serializes type and
+  integral arguments directly. Pack arguments are flattened into a comma-separated
+  string such as ``"int, float, double"``. Template argument kinds that are not
+  yet represented by ast_canopy are preserved as the placeholder
+  ``"<unsupported>"`` so parsing can continue.
 
 Example mapping
 ---------------
@@ -133,6 +149,17 @@ Notes and edge cases
   - ``Typedef.underlying_name`` matching ``unnamed<ID>``
   - ``Record.name`` matching ``unnamed<ID>``
   - ``Record.qual_name == "CStyleAnon"``
+
+- **Typedefs of class template specializations**: for aliases like
+
+  .. code-block:: cpp
+
+     template <typename T, int N> struct Storage {};
+     typedef Storage<float, 3> FloatStorage;
+
+  ``Typedef.name`` and ``Typedef.qual_name`` describe the alias, while
+  ``Typedef.underlying_name`` describes the underlying specialization, for
+  example ``Storage<float, 3>``.
 
 Supported argument types
 ------------------------


### PR DESCRIPTION
## Summary

- Document recent ast_canopy serialization behavior for layout sentinels, dependent-signature mangled-name fallbacks, template parameter packs, unsupported template arguments, and typedef aliases of class-template specializations.
- Add dynamic binding guidance for `bind_cxx_struct(name=...)` and `numbast.types.register_cxx_type`.
- Include `numbast.types` in the API reference autosummary.

## Test plan

- [x] `git diff --check`
- [x] Pre-commit hooks during commit, including `doc8` and `rstcheck`
- [x] `pixi run -e test-cu13 python -m sphinx -b html docs/source /tmp/numbast-docs-check2`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Included the `types` submodule in the API reference autosummary.
  * Added guidance for overriding C++ type spelling when binding structs via a `name=` option.
  * Documented using `register_cxx_type` to map unparsed C++ names to known types, with examples.
  * Clarified serialization behavior for declarations: record layouts, function identity, template parameter metadata, template specialization arguments, and typedef alias handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->