### PR TITLE
[codex] Align C ABI allocas for CUDA vector types

### DIFF
--- a/numbast/src/numbast/callconv.py
+++ b/numbast/src/numbast/callconv.py
@@ -10,6 +10,28 @@ from numba.cuda import types, cgutils
 from llvmlite import ir
 
 
+def _alloca_alignment(context, llvm_ty, numba_ty=None):
+    """Return the alignment to use for a local ABI slot.
+
+    LLVM's ABI alignment can be too small for CUDA built-in vector types
+    represented as LLVM structs.  For example, ``float2`` lowers to a
+    ``{float, float}`` struct whose default alloca alignment is 4, while CUDA
+    vector loads/stores require 8-byte alignment.  Numbast type maps can attach
+    an explicit ``alignof_`` to such Numba types; honor it for the stack slot
+    itself, not only for later stores/loads.
+    """
+    abi_align = context.target_data.abi_alignment(llvm_ty)
+    explicit_align = getattr(numba_ty, "alignof_", None)
+    if explicit_align is None:
+        return abi_align
+    return max(abi_align, explicit_align)
+
+
+def _set_alloca_alignment(ptr, context, llvm_ty, numba_ty=None):
+    ptr.align = _alloca_alignment(context, llvm_ty, numba_ty)
+    return ptr
+
+
 class BaseCallConv:
     shim_function_template = "{mangled_name}_nbst"
 
@@ -104,9 +126,13 @@ class FunctionCallConv(BaseCallConv):
             # Void return type in C++ is shimmed as int& ignored
             retval_ty = ir.IntType(32)
             retval_ptr = builder.alloca(retval_ty, name="ignored")
+            _set_alloca_alignment(retval_ptr, context, retval_ty)
         else:
             retval_ty = context.get_value_type(cxx_return_type)
             retval_ptr = builder.alloca(retval_ty, name="retval")
+            _set_alloca_alignment(
+                retval_ptr, context, retval_ty, cxx_return_type
+            )
 
         # 2. Prepare arguments
         if self._intent_plan is None:
@@ -154,6 +180,7 @@ class FunctionCallConv(BaseCallConv):
                     ptrs.append(arg)
                 else:
                     ptr = cgutils.alloca_once(builder, vty)
+                    _set_alloca_alignment(ptr, context, vty, argty)
                     builder.store(
                         arg, ptr, align=getattr(argty, "alignof_", None)
                     )
@@ -175,6 +202,7 @@ class FunctionCallConv(BaseCallConv):
                     out_nbty = self._out_return_types[out_pos]
                     vty = context.get_value_type(out_nbty)
                     ptr = cgutils.alloca_once(builder, vty)
+                    _set_alloca_alignment(ptr, context, vty, out_nbty)
                     ptrs.append(ptr)
                     arg_pointer_types.append(ir.PointerType(vty))
                     out_return_ptrs.append((out_nbty, ptr))
@@ -194,6 +222,7 @@ class FunctionCallConv(BaseCallConv):
                     arg_pointer_types.append(vty)
                 else:
                     ptr = cgutils.alloca_once(builder, vty)
+                    _set_alloca_alignment(ptr, context, vty, argty)
                     builder.store(
                         arg, ptr, align=getattr(argty, "alignof_", None)
                     )

--- a/numbast/src/numbast/types.py
+++ b/numbast/src/numbast/types.py
@@ -13,6 +13,24 @@ from numba.cuda._internal.cuda_bf16 import _type_unnamed1405307
 from cuda.bindings import runtime
 
 
+CUDA_VECTOR_TYPE_ALIGNMENTS = {
+    # CUDA vector_types.h gives 2-lane 32-bit vectors 8-byte alignment and
+    # 4-lane 32-bit vectors 16-byte alignment.  LLVM represents these as
+    # ordinary structs, whose ABI alignment would otherwise be only 4.
+    "uint32x2": 8,
+    "uint32x4": 16,
+    "float32x2": 8,
+    "float32x4": 16,
+    # CUDA double2 is explicitly 16-byte aligned.  Keep double4 at 16 as well;
+    # over-aligning a local slot is safe and matches CUDA's vector access needs.
+    "float64x2": 16,
+    "float64x4": 16,
+}
+
+for _vector_type_name, _alignment in CUDA_VECTOR_TYPE_ALIGNMENTS.items():
+    vector_types[_vector_type_name].alignof_ = _alignment
+
+
 class FunctorType(nbtypes.Type):
     def __init__(self, name):
         super().__init__(name=name + "FunctorType")

--- a/numbast/tests/test_callconv.py
+++ b/numbast/tests/test_callconv.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from llvmlite import ir
+from numba.cuda.vector_types import vector_types
+
+import numbast.types  # noqa: F401 - registers CUDA vector alignments
+from numbast.callconv import _alloca_alignment, _set_alloca_alignment
+
+
+class _TargetData:
+    def __init__(self, abi_alignment):
+        self._abi_alignment = abi_alignment
+
+    def abi_alignment(self, _llvm_ty):
+        return self._abi_alignment
+
+
+class _Context:
+    def __init__(self, abi_alignment):
+        self.target_data = _TargetData(abi_alignment)
+
+
+def _builder():
+    module = ir.Module()
+    func_ty = ir.FunctionType(ir.VoidType(), ())
+    func = ir.Function(module, func_ty, "test_func")
+    block = func.append_basic_block("entry")
+    return ir.IRBuilder(block)
+
+
+def test_cuda_vector_type_alignments_are_registered():
+    assert vector_types["float32x2"].alignof_ == 8
+    assert vector_types["float32x4"].alignof_ == 16
+    assert vector_types["uint32x2"].alignof_ == 8
+    assert vector_types["uint32x4"].alignof_ == 16
+
+
+def test_alloca_alignment_uses_explicit_numba_type_alignment():
+    llvm_ty = ir.LiteralStructType([ir.FloatType(), ir.FloatType()])
+    align = _alloca_alignment(
+        _Context(abi_alignment=4), llvm_ty, vector_types["float32x2"]
+    )
+    assert align == 8
+
+
+def test_alloca_alignment_falls_back_to_llvm_abi_alignment():
+    llvm_ty = ir.IntType(32)
+    align = _alloca_alignment(_Context(abi_alignment=4), llvm_ty)
+    assert align == 4
+
+
+def test_set_alloca_alignment_writes_alignment_to_alloca():
+    builder = _builder()
+    llvm_ty = ir.LiteralStructType([ir.FloatType(), ir.FloatType()])
+    ptr = builder.alloca(llvm_ty, name="retval")
+
+    _set_alloca_alignment(
+        ptr, _Context(abi_alignment=4), llvm_ty, vector_types["float32x2"]
+    )
+
+    assert ptr.align == 8


### PR DESCRIPTION
## Summary

- Assign CUDA vector alignments to Numbast vector type mappings.
- Align FunctionCallConv return, argument, and out-return allocas using explicit type alignment when available.
- Add focused unit tests for vector alloca alignment behavior.

## Why

CUDA vector returns such as `float2` can lower to LLVM structs with too-small default stack alignment. Honoring `alignof_` on the alloca itself prevents generated C ABI shims from creating under-aligned local slots.

## Validation

- `PYTHONPATH=/tmp/numbast-callconv-vector-align/numbast/src /home/wangm/numbast-pixi-testing/.pixi/envs/test-cu13/bin/python -m pytest numbast/tests/test_callconv.py`
- `/home/wangm/numbast-pixi-testing/.pixi/envs/test-cu13/bin/python -m ruff check numbast/src/numbast/callconv.py numbast/src/numbast/types.py numbast/tests/test_callconv.py`
- Pre-commit hooks during commit

I also attempted `pytest numbast/tests/test_callconv.py numbast/tests/test_function.py -q`; the GPU-dependent `test_function.py` path failed because this environment reports no CUDA device.
