### PR TITLE
[codex] Add CUDA vector type C mappings

### DIFF
--- a/numbast/src/numbast/types.py
+++ b/numbast/src/numbast/types.py
@@ -58,19 +58,31 @@ ENUM_TYPE_MAPS = {
     ),
 }
 
+CUDA_VECTOR_TYPE_MAPS = {
+    f"{cxx_name}{lanes}": vector_types[f"{numba_name}x{lanes}"]
+    for cxx_name, numba_name in (
+        ("char", "int8"),
+        ("uchar", "uint8"),
+        ("short", "int16"),
+        ("ushort", "uint16"),
+        ("int", "int32"),
+        ("uint", "uint32"),
+        ("longlong", "int64"),
+        ("ulonglong", "uint64"),
+        ("float", "float32"),
+        ("double", "float64"),
+    )
+    for lanes in (1, 2, 3, 4)
+}
+
 CTYPE_MAPS = {
     **INTEGER_TYPE_MAPS,
     **FLOATING_TYPE_MAPS,
     **CCCL_Types,
     **ENUM_TYPE_MAPS,
+    **CUDA_VECTOR_TYPE_MAPS,
     "void": nbtypes.void,
     "bool": nbtypes.bool_,
-    "uint4": vector_types["uint32x4"],
-    "uint2": vector_types["uint32x2"],
-    "float2": vector_types["float32x2"],
-    "float4": vector_types["float32x4"],
-    "double2": vector_types["float64x2"],
-    "double4": vector_types["float64x4"],
 }
 
 
@@ -88,6 +100,10 @@ NUMBA_TO_CTYPE_MAPS = {
     nbtypes.float64: "double",
     nbtypes.bool_: "bool",
     nbtypes.void: "void",
+    **{
+        numba_type: cxx_name
+        for cxx_name, numba_type in CUDA_VECTOR_TYPE_MAPS.items()
+    },
 }
 
 

--- a/numbast/tests/test_cuda_vector_types.py
+++ b/numbast/tests/test_cuda_vector_types.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from numba import types as nbtypes
+from numba.cuda.vector_types import vector_types
+
+from numbast.types import to_c_type_str, to_numba_type
+
+
+def test_cuda_vector_types_map_to_numba_types():
+    assert to_numba_type("float3") == vector_types["float32x3"]
+    assert to_numba_type("float4") == vector_types["float32x4"]
+    assert to_numba_type("uint4") == vector_types["uint32x4"]
+    assert to_numba_type("uchar4") == vector_types["uint8x4"]
+
+
+def test_cuda_vector_types_map_back_to_c_type_strings():
+    assert to_c_type_str(vector_types["float32x3"]) == "float3"
+    assert to_c_type_str(vector_types["float32x4"]) == "float4"
+    assert to_c_type_str(vector_types["uint32x4"]) == "uint4"
+    assert to_c_type_str(vector_types["uint8x4"]) == "uchar4"
+
+
+def test_cuda_vector_pointer_types_map_back_to_c_type_strings():
+    assert (
+        to_c_type_str(nbtypes.CPointer(vector_types["float32x3"])) == "float3*"
+    )
+    assert (
+        to_c_type_str(nbtypes.CPointer(vector_types["float32x4"])) == "float4*"
+    )


### PR DESCRIPTION
## Summary

- Add a shared CUDA vector type registry for `charN`, `ucharN`, `shortN`, `ushortN`, `intN`, `uintN`, `longlongN`, `ulonglongN`, `floatN`, and `doubleN`.
- Feed those mappings into both C++ to Numba and Numba to C++ type conversion.
- Add focused tests for vector return and pointer C type string conversion.

## Why

Numbast could parse some CUDA vector C types into Numba vector types, but `to_c_type_str()` could not convert those Numba vector types back into C type strings. That blocks generated shims for APIs returning vectors, taking vector pointers, or using vector out-parameters.

## Validation

- `PYTHONPATH=/tmp/numbast-cuda-vector-type-maps/numbast/src /home/wangm/numbast-pixi-testing/.pixi/envs/test-cu13/bin/python -m pytest numbast/tests/test_cuda_vector_types.py`
- `/home/wangm/numbast-pixi-testing/.pixi/envs/test-cu13/bin/python -m ruff check numbast/src/numbast/types.py numbast/tests/test_cuda_vector_types.py`
- Pre-commit hooks during commit
