### PR TITLE
test: pin cuda-core test dependency

### DIFF
--- a/numbast/pyproject.toml
+++ b/numbast/pyproject.toml
@@ -39,11 +39,17 @@ issues = "https://github.com/NVIDIA/numbast/issues"
 [project.optional-dependencies]
 dev = ["ruff"]
 docs = ["sphinx>=7.0", "sphinx-copybutton>=0.5.2"]
-test-cu12 = ["pytest", "cffi", "numba-cuda[cu12]>=0.25.0"]
+test-cu12 = [
+  "pytest",
+  "cffi",
+  "cuda-core>=0.7.0,<2.0.0",
+  "numba-cuda[cu12]>=0.25.0",
+]
 test-cu13 = [
   "pytest",
   "cffi",
   "cuda-toolkit[cudart,crt,curand,cccl,nvcc]==13.*",
+  "cuda-core>=0.7.0,<2.0.0",
   "numba-cuda[cu13]>=0.25.0",
 ]
 

--- a/numbast/src/numbast/tools/tests/test_symbol_exposure.py
+++ b/numbast/src/numbast/tools/tests/test_symbol_exposure.py
@@ -5,7 +5,7 @@ import os
 import subprocess
 import sys
 
-from cuda.core.experimental import Device
+from cuda.core import Device
 
 dev = Device(0)
 cc = dev.compute_capability

--- a/pixi.lock
+++ b/pixi.lock
@@ -7,6 +7,8 @@ environments:
     - url: https://conda.anaconda.org/nvidia/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -48,7 +50,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cccl_linux-64-13.0.85-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-command-line-tools-13.0.2-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-compiler-13.0.2-hbad6d8a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-core-0.6.0-cuda13_py313h83ce759_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-core-0.7.0-cuda13_py313h83ce759_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-crt-dev_linux-64-13.0.88-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-crt-tools-13.0.88-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-ctadvisor-13.0.85-h676940d_0.conda
@@ -84,7 +86,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvvm-tools-13.0.88-h4bc722e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-opencl-13.0.85-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-opencl-dev-13.0.85-hecca717_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-pathfinder-1.3.5-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-pathfinder-1.5.4-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-profiler-api-13.0.85-h7938cbb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-python-13.0.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-sanitizer-api-13.0.85-h10ca0ad_0.conda
@@ -305,6 +307,8 @@ environments:
     - url: https://conda.anaconda.org/nvidia/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -346,7 +350,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cccl_linux-64-12.9.27-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-command-line-tools-12.9.1-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-compiler-12.9.1-hbad6d8a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-core-0.6.0-cuda12_py313hacc9b55_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-core-0.7.0-cuda12_py313hacc9b55_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-crt-dev_linux-64-12.9.86-ha770c72_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-crt-tools-12.9.86-ha770c72_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-cudart-12.9.79-h5888daf_0.conda
@@ -383,7 +387,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvvp-12.9.79-hbd13f7d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-opencl-12.9.19-h5888daf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-opencl-dev-12.9.19-h5888daf_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-pathfinder-1.3.5-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-pathfinder-1.5.4-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-profiler-api-12.9.79-h7938cbb_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-python-12.9.5-pyh698daf1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-sanitizer-api-12.9.79-h10ca0ad_1.conda
@@ -604,6 +608,8 @@ environments:
     - url: https://conda.anaconda.org/nvidia/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -645,7 +651,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-cccl_linux-64-13.0.85-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-command-line-tools-13.0.2-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-compiler-13.0.2-hbad6d8a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-core-0.6.0-cuda13_py313h83ce759_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-core-0.7.0-cuda13_py313h83ce759_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-crt-dev_linux-64-13.0.88-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-crt-tools-13.0.88-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-ctadvisor-13.0.85-h676940d_0.conda
@@ -681,7 +687,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-nvvm-tools-13.0.88-h4bc722e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-opencl-13.0.85-hecca717_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-opencl-dev-13.0.85-hecca717_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-pathfinder-1.3.5-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-pathfinder-1.5.4-pyhc364b38_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-profiler-api-13.0.85-h7938cbb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-python-13.0.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-sanitizer-api-13.0.85-h10ca0ad_0.conda
@@ -1500,12 +1506,13 @@ packages:
   purls: []
   size: 20690
   timestamp: 1760039227660
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-core-0.6.0-cuda12_py313hacc9b55_0.conda
-  sha256: 7886821cd8ec0c94e20948b7e815c80ba295ac7744990948d6f98d10343e3050
-  md5: 1986c17fb0b8184289ea7d6fc8ba4b34
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-core-0.7.0-cuda12_py313hacc9b55_0.conda
+  sha256: 2cee94369d1ecbd47b7d71bf2a11e62039281b6b43fb8071f33c9694041562f7
+  md5: d1030d02b04b3a15bc6f06b763c6f0d9
   depends:
   - __glibc >=2.17,<3.0.a0
   - cuda-bindings >=12,<13.0a0
+  - cuda-pathfinder >=1.4.2,<2
   - cuda-version >=12,<13.0a0
   - libgcc >=14
   - libstdcxx >=14
@@ -1516,14 +1523,15 @@ packages:
   license_family: APACHE
   purls:
   - pkg:pypi/cuda-core?source=hash-mapping
-  size: 1136276
-  timestamp: 1771887006873
-- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-core-0.6.0-cuda13_py313h83ce759_0.conda
-  sha256: da2d5a0f254ccd4c27c389babe9a56f4837e732fd139706976f541dcd2b3c0e6
-  md5: bda06bad2a08d72d9c04a57f05f14990
+  size: 1521992
+  timestamp: 1775673911064
+- conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-core-0.7.0-cuda13_py313h83ce759_0.conda
+  sha256: f220835ef7dfab77d004908541ae9c3dd8c344ed9cb884d8878a9b95210a87f7
+  md5: 74f0931ce083f5764fb166c7c33d6664
   depends:
   - __glibc >=2.17,<3.0.a0
   - cuda-bindings >=13,<14.0a0
+  - cuda-pathfinder >=1.4.2,<2
   - cuda-version >=13,<14.0a0
   - libgcc >=14
   - libstdcxx >=14
@@ -1534,8 +1542,8 @@ packages:
   license_family: APACHE
   purls:
   - pkg:pypi/cuda-core?source=hash-mapping
-  size: 1140845
-  timestamp: 1771886738046
+  size: 1535383
+  timestamp: 1775673907708
 - conda: https://conda.anaconda.org/conda-forge/noarch/cuda-crt-dev_linux-64-12.9.86-ha770c72_2.conda
   sha256: e6257534c4b4b6b8a1192f84191c34906ab9968c92680fa09f639e7846a87304
   md5: 79d280de61e18010df5997daea4743df
@@ -2447,9 +2455,9 @@ packages:
   purls: []
   size: 98920
   timestamp: 1757021224462
-- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-pathfinder-1.3.5-pyhcf101f3_0.conda
-  sha256: 561b74baebda93e15fe34f13ddac474e06899f77823729964fd7760ee04841a3
-  md5: 50f73ddfb22b716fd1a5cd7a4023e7f3
+- conda: https://conda.anaconda.org/conda-forge/noarch/cuda-pathfinder-1.5.4-pyhc364b38_0.conda
+  sha256: 662046880e1dd8f62cd2ad8ac9618ace683cb7a3f3af93c52e425a772c9b4f00
+  md5: 42d4610b52102122741f9bf68f2866ed
   depends:
   - python >=3.10
   - cuda-version >=12.0,<14
@@ -2458,8 +2466,8 @@ packages:
   license_family: APACHE
   purls:
   - pkg:pypi/cuda-pathfinder?source=hash-mapping
-  size: 35977
-  timestamp: 1771891419934
+  size: 45892
+  timestamp: 1777330272729
 - conda: https://conda.anaconda.org/conda-forge/linux-64/cuda-profiler-api-12.9.79-h7938cbb_1.conda
   sha256: 4f679dfbf2bf2d17abb507f31b0176c0e3572337b5005b9e36179948a53988ac
   md5: 90d09865fb37d11d510444e34ebe6a09

--- a/pixi.toml
+++ b/pixi.toml
@@ -41,6 +41,7 @@ cuda = "12"
 
 [feature.cu12.dependencies]
 numba-cuda = ">=0.25.0"
+cuda-core = ">=0.7.0,<2.0.0"
 cuda-version = "12.9.*"
 cuda-toolkit = "12.9.*"
 cuda-python = "12.9.*"
@@ -50,6 +51,7 @@ cuda = "13"
 
 [feature.cu13.dependencies]
 numba-cuda = ">=0.25.0"
+cuda-core = ">=0.7.0,<2.0.0"
 cuda-version = "13.0.*"
 cuda-toolkit = "13.0.*"
 cuda-python = "13.0.*"


### PR DESCRIPTION
## Summary
- add an explicit cuda-core>=0.7.0,<2.0.0 constraint to the test-cu12/test-cu13 extras and Pixi CUDA test environments
- update the symbol exposure test to import Device from cuda.core instead of cuda.core.experimental
- refresh pixi.lock to cuda-core 0.7.0 for test environments

## Testing
- pixi lock --check
- PYTHONPATH=/tmp/cuda-core-force-1-sitecustomize /tmp/numbast-cuda-core-1.0/.venv/bin/python -c 'from cuda import core; print(core.__version__); from cuda.core import Device; print(Device)'
- PATH=/tmp/numbast-cuda-core-1.0/.venv/bin:/home/wangm/.local/bin:/home/wangm/bin:/home/wangm/.codex/tmp/arg0/codex-arg0EX70oy:/home/wangm/.nvm/versions/node/v24.14.0/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/path:/home/wangm/.local/bin:/home/wangm/bin:/home/wangm/.pixi/bin:/home/wangm/.local/bin:/home/wangm/bin:/home/wangm/.nvm/versions/node/v24.14.0/bin:/usr/local/cuda/bin:/home/wangm/.pixi/bin:/home/wangm/bin:/home/wangm/miniforge3/bin:/home/wangm/miniforge3/condabin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/opt/p4v/bin:/opt/pycharm-community-2020.3.3/bin:/opt/p4v/bin:/opt/pycharm-community-2020.3.3/bin PYTHONPATH=/tmp/cuda-core-force-1-sitecustomize LD_PRELOAD=/tmp/numbast-cuda-core-1.0/.venv/lib/libastcanopy.so /tmp/numbast-cuda-core-1.0/.venv/bin/python -m pytest numbast/src/numbast/tools/tests/test_symbol_exposure.py -q --tb=short -ra
- PATH=/tmp/numbast-cuda-core-1.0/.venv/bin:/home/wangm/.local/bin:/home/wangm/bin:/home/wangm/.codex/tmp/arg0/codex-arg0EX70oy:/home/wangm/.nvm/versions/node/v24.14.0/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/path:/home/wangm/.local/bin:/home/wangm/bin:/home/wangm/.pixi/bin:/home/wangm/.local/bin:/home/wangm/bin:/home/wangm/.nvm/versions/node/v24.14.0/bin:/usr/local/cuda/bin:/home/wangm/.pixi/bin:/home/wangm/bin:/home/wangm/miniforge3/bin:/home/wangm/miniforge3/condabin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/opt/p4v/bin:/opt/pycharm-community-2020.3.3/bin:/opt/p4v/bin:/opt/pycharm-community-2020.3.3/bin PYTHONPATH=/tmp/cuda-core-force-1-sitecustomize LD_PRELOAD=/tmp/numbast-cuda-core-1.0/.venv/lib/libastcanopy.so /tmp/numbast-cuda-core-1.0/.venv/bin/python -m pytest numbast/tests/test_shim_writer.py -q --tb=short -ra

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CUDA core dependency constraints (`>=0.7.0,<2.0.0`) across testing and feature configurations.

* **Tests**
  * Modified symbol exposure test to adjust expected symbol counts based on CUDA compute capability levels.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/numbast/pull/339)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->