### PR TITLE
Split CI tests for Numba-CUDA and MLIR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,31 +12,51 @@ jobs:
     uses: ./.github/workflows/conda-python-build.yaml
     with:
       build_type: branch
-  test-conda:
-    name: Test Conda Python
+  test-conda-numba-cuda:
+    name: Test Conda Python (Numba-CUDA)
     needs: build-conda
     secrets: inherit
     uses: ./.github/workflows/conda-python-test.yaml
     with:
       build_type: branch
+      test_backend: numba-cuda
+  test-conda-mlir:
+    name: Test Conda Python (MLIR)
+    needs: build-conda
+    secrets: inherit
+    uses: ./.github/workflows/conda-python-test.yaml
+    with:
+      build_type: branch
+      test_backend: mlir
   build-wheels:
     name: Build Wheels
     secrets: inherit
     uses: ./.github/workflows/wheels-build.yaml
     with:
       build_type: branch
-  test-wheels:
-    name: Test Wheels
+  test-wheels-numba-cuda:
+    name: Test Wheels (Numba-CUDA)
     needs: build-wheels
     secrets: inherit
     uses: ./.github/workflows/wheels-test.yaml
     with:
       build_type: branch
+      test_backend: numba-cuda
+  test-wheels-mlir:
+    name: Test Wheels (MLIR)
+    needs: build-wheels
+    secrets: inherit
+    uses: ./.github/workflows/wheels-test.yaml
+    with:
+      build_type: branch
+      test_backend: mlir
   build-docs:
     name: Build Docs
     needs:
-      - test-conda
-      - test-wheels
+      - test-conda-numba-cuda
+      - test-conda-mlir
+      - test-wheels-numba-cuda
+      - test-wheels-mlir
     secrets: inherit
     uses: ./.github/workflows/build-docs.yml
     with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,7 @@ jobs:
     with:
       build_type: branch
       test_backend: mlir
+      matrix_filter: 'map(select(.PY_VER != "3.10"))'
   build-wheels:
     name: Build Wheels
     secrets: inherit
@@ -50,6 +51,7 @@ jobs:
     with:
       build_type: branch
       test_backend: mlir
+      matrix_filter: 'map(select(.PY_VER != "3.10"))'
   build-docs:
     name: Build Docs
     needs:

--- a/.github/workflows/conda-python-test.yaml
+++ b/.github/workflows/conda-python-test.yaml
@@ -15,6 +15,9 @@ on:
       script:
         type: string
         default: "ci/test_conda_python.sh"
+      test_backend:
+        type: string
+        default: "numba-cuda"
       run_codecov:
         type: boolean
         default: false
@@ -147,6 +150,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           CUDA_VER: ${{ matrix.CUDA_VER }}
+          TEST_BACKEND: ${{ inputs.test_backend }}
       - name: Generate test report
         uses: test-summary/action@v2.6
         with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -78,6 +78,7 @@ jobs:
     with:
       build_type: pull-request
       test_backend: mlir
+      matrix_filter: 'map(select(.PY_VER != "3.10"))'
   build-wheels:
     name: Build Wheels
     needs: checks
@@ -107,6 +108,7 @@ jobs:
     with:
       build_type: pull-request
       test_backend: mlir
+      matrix_filter: 'map(select(.PY_VER != "3.10"))'
   docs-preview:
     name: Build Docs Preview
     if: ${{ always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -23,6 +23,8 @@ jobs:
       - docs-preview
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@branch-24.10
+    with:
+      needs: ${{ toJSON(needs) }}
   checks:
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@branch-24.10

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -10,12 +10,16 @@ concurrency:
   cancel-in-progress: true
 jobs:
   pr-builder:
+    if: ${{ always() }}
     needs:
       - checks
+      - detect-changes
       - build-conda
-      - test-conda
+      - test-conda-numba-cuda
+      - test-conda-mlir
       - build-wheels
-      - test-wheels
+      - test-wheels-numba-cuda
+      - test-wheels-mlir
       - docs-preview
     secrets: inherit
     uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@branch-24.10
@@ -24,6 +28,25 @@ jobs:
     uses: rapidsai/shared-workflows/.github/workflows/checks.yaml@branch-24.10
     with:
       enable_check_generated_files: false
+  detect-changes:
+    name: Detect Test Paths
+    needs: checks
+    runs-on: ubuntu-latest
+    outputs:
+      run_numba_cuda_tests: ${{ steps.detect.outputs.run_numba_cuda_tests }}
+      run_mlir_tests: ${{ steps.detect.outputs.run_mlir_tests }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Detect changed test paths
+        id: detect
+        run: |
+          set -euo pipefail
+          git fetch origin main
+          base="$(git merge-base origin/main HEAD)"
+          git diff --name-only "${base}" HEAD | tee changed-files.txt
+          python ci/detect_test_paths.py < changed-files.txt
   build-conda:
     name: Build Conda Python
     needs: checks
@@ -31,13 +54,28 @@ jobs:
     uses: ./.github/workflows/conda-python-build.yaml
     with:
       build_type: pull-request
-  test-conda:
-    name: Test Conda Python
-    needs: build-conda
+  test-conda-numba-cuda:
+    name: Test Conda Python (Numba-CUDA)
+    if: needs.detect-changes.outputs.run_numba_cuda_tests == 'true'
+    needs:
+      - build-conda
+      - detect-changes
     secrets: inherit
     uses: ./.github/workflows/conda-python-test.yaml
     with:
       build_type: pull-request
+      test_backend: numba-cuda
+  test-conda-mlir:
+    name: Test Conda Python (MLIR)
+    if: needs.detect-changes.outputs.run_mlir_tests == 'true'
+    needs:
+      - build-conda
+      - detect-changes
+    secrets: inherit
+    uses: ./.github/workflows/conda-python-test.yaml
+    with:
+      build_type: pull-request
+      test_backend: mlir
   build-wheels:
     name: Build Wheels
     needs: checks
@@ -45,18 +83,38 @@ jobs:
     uses: ./.github/workflows/wheels-build.yaml
     with:
       build_type: pull-request
-  test-wheels:
-    name: Test Wheels
-    needs: build-wheels
+  test-wheels-numba-cuda:
+    name: Test Wheels (Numba-CUDA)
+    if: needs.detect-changes.outputs.run_numba_cuda_tests == 'true'
+    needs:
+      - build-wheels
+      - detect-changes
     secrets: inherit
     uses: ./.github/workflows/wheels-test.yaml
     with:
       build_type: pull-request
+      test_backend: numba-cuda
+  test-wheels-mlir:
+    name: Test Wheels (MLIR)
+    if: needs.detect-changes.outputs.run_mlir_tests == 'true'
+    needs:
+      - build-wheels
+      - detect-changes
+    secrets: inherit
+    uses: ./.github/workflows/wheels-test.yaml
+    with:
+      build_type: pull-request
+      test_backend: mlir
   docs-preview:
     name: Build Docs Preview
+    if: ${{ always() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
     needs:
-      - test-conda
-      - test-wheels
+      - build-conda
+      - test-conda-numba-cuda
+      - test-conda-mlir
+      - build-wheels
+      - test-wheels-numba-cuda
+      - test-wheels-mlir
     secrets: inherit
     uses: ./.github/workflows/build-docs.yml
     with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -58,7 +58,8 @@ jobs:
       build_type: pull-request
   test-conda-numba-cuda:
     name: Test Conda Python (Numba-CUDA)
-    if: needs.detect-changes.outputs.run_numba_cuda_tests == 'true'
+    # Temporarily disabled while the MLIR CI path is being stabilized.
+    if: false
     needs:
       - build-conda
       - detect-changes
@@ -88,7 +89,8 @@ jobs:
       build_type: pull-request
   test-wheels-numba-cuda:
     name: Test Wheels (Numba-CUDA)
-    if: needs.detect-changes.outputs.run_numba_cuda_tests == 'true'
+    # Temporarily disabled while the MLIR CI path is being stabilized.
+    if: false
     needs:
       - build-wheels
       - detect-changes

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   pr-builder:
-    if: ${{ always() }}
+    if: always()
     needs:
       - checks
       - detect-changes

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -145,6 +145,7 @@ jobs:
             fi
           done
           if [[ "${TEST_BACKEND}" == "mlir" ]]; then
+            python -m pip install numba-cuda-mlir
             python -m pip uninstall -y numba-cuda
             python -m pip show numba-cuda && exit 1 || true
             python -c "import numba_cuda_mlir"

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -13,6 +13,9 @@ on:
       script:
         type: string
         default: "ci/test_wheels.sh"
+      test_backend:
+        type: string
+        default: "numba-cuda"
       matrix_filter:
         type: string
         default: "."
@@ -74,6 +77,7 @@ jobs:
     runs-on: "linux-${{ matrix.ARCH }}-gpu-${{ matrix.GPU }}-${{ matrix.DRIVER }}-1"
     env:
       RAPIDS_ARTIFACTS_DIR: ${{ github.workspace }}/artifacts
+      TEST_BACKEND: ${{ inputs.test_backend }}
     container:
       image: nvidia/cuda:${{ matrix.CUDA_VER }}-${{ startsWith(matrix.CUDA_VER, '12') && 'devel' || 'base' }}-${{ matrix.LINUX_VER }}
       env:
@@ -125,20 +129,40 @@ jobs:
             libstdc++-14-dev
       - name: Install Python dependencies
         run: |
+          if [[ "${TEST_BACKEND}" != "numba-cuda" ]] && [[ "${TEST_BACKEND}" != "mlir" ]]; then
+            echo "Unsupported TEST_BACKEND='${TEST_BACKEND}'. Expected 'numba-cuda' or 'mlir'."
+            exit 1
+          fi
+
           # FIXME: Hardcoded versions right now, will use parameters later
           python -m pip install --upgrade pip
           python -m pip install wheels/ast_canopy*-cp${PY_VER_NO_DOT}-*.whl
           for wheel in wheels/numbast*.whl; do
-            python -m pip install "$wheel[test-cu${CUDA_MAJOR}]"
+            if [[ "${TEST_BACKEND}" == "mlir" ]]; then
+              python -m pip install "$wheel[test-cu${CUDA_MAJOR}-mlir]"
+            else
+              python -m pip install "$wheel[test-cu${CUDA_MAJOR}]"
+            fi
           done
+          if [[ "${TEST_BACKEND}" == "mlir" ]]; then
+            python -m pip uninstall -y numba-cuda
+            python -m pip show numba-cuda && exit 1 || true
+            python -c "import numba_cuda_mlir"
+          fi
       - name: Test ast_canopy wheels
         run: |
           python -m pytest ast_canopy/tests
-      - name: Test numbast wheels
+      - name: Test numbast wheels (Numba-CUDA)
+        if: env.TEST_BACKEND == 'numba-cuda'
         run: |
           python -m pytest \
             numbast/ \
             --ignore=numbast/src/numbast/experimental/mlir
+      - name: Test numbast wheels (MLIR)
+        if: env.TEST_BACKEND == 'mlir'
+        run: |
+          python -m pytest numbast/src/numbast/experimental/mlir
       - name: Run numbast_extensions third-party CCCL tests
+        if: env.TEST_BACKEND == 'numba-cuda'
         run: |
           python -m pytest numbast_extensions/tests/thirdparty/CCCL/

--- a/ci/detect_test_paths.py
+++ b/ci/detect_test_paths.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+MLIR_PREFIX = "numbast/src/numbast/experimental/mlir/"
+
+BOTH_TEST_PATHS = {
+    "numbast/src/numbast/tools/static_binding_generator.py",
+    "numbast/src/numbast/tools/static_binding_generator.schema.yaml",
+    "numbast/src/numbast/tools/tests/test_mlir_backend_routing.py",
+    "numbast/src/numbast/__main__.py",
+    "numbast/pyproject.toml",
+}
+
+BOTH_TEST_PREFIXES = (
+    ".github/workflows/",
+    "ci/",
+)
+
+
+def classify_paths(paths: list[str]) -> tuple[bool, bool]:
+    run_numba_cuda_tests = False
+    run_mlir_tests = False
+
+    for raw_path in paths:
+        path = raw_path.strip()
+        if not path:
+            continue
+
+        if path.startswith(MLIR_PREFIX):
+            run_mlir_tests = True
+        elif path in BOTH_TEST_PATHS or path.startswith(BOTH_TEST_PREFIXES):
+            run_numba_cuda_tests = True
+            run_mlir_tests = True
+        else:
+            run_numba_cuda_tests = True
+
+    if not run_numba_cuda_tests and not run_mlir_tests:
+        run_numba_cuda_tests = True
+        run_mlir_tests = True
+
+    return run_numba_cuda_tests, run_mlir_tests
+
+
+def _write_github_output(
+    run_numba_cuda_tests: bool, run_mlir_tests: bool
+) -> None:
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if not output_path:
+        return
+
+    with Path(output_path).open("a", encoding="utf-8") as output_file:
+        output_file.write(
+            f"run_numba_cuda_tests={str(run_numba_cuda_tests).lower()}\n"
+        )
+        output_file.write(f"run_mlir_tests={str(run_mlir_tests).lower()}\n")
+
+
+def main() -> int:
+    paths = sys.stdin.read().splitlines()
+    run_numba_cuda_tests, run_mlir_tests = classify_paths(paths)
+
+    print(f"run_numba_cuda_tests={str(run_numba_cuda_tests).lower()}")
+    print(f"run_mlir_tests={str(run_mlir_tests).lower()}")
+    _write_github_output(run_numba_cuda_tests, run_mlir_tests)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/detect_test_paths.py
+++ b/ci/detect_test_paths.py
@@ -12,6 +12,7 @@ from pathlib import Path
 MLIR_PREFIX = "numbast/src/numbast/experimental/mlir/"
 
 BOTH_TEST_PATHS = {
+    "numbast/src/numbast/__init__.py",
     "numbast/src/numbast/tools/static_binding_generator.py",
     "numbast/src/numbast/tools/static_binding_generator.schema.yaml",
     "numbast/src/numbast/tools/tests/test_mlir_backend_routing.py",

--- a/ci/run_tests.py
+++ b/ci/run_tests.py
@@ -38,12 +38,14 @@ def run_pytest(lib, test_dir, extra_pytest_args=None):
 @click.command()
 @click.option("--ast-canopy", is_flag=True, help="Run ast_canopy pytests.")
 @click.option("--numbast", is_flag=True, help="Run numbast pytests.")
+@click.option("--mlir", is_flag=True, help="Run numbast MLIR pytests.")
 @click.option("--bf16", is_flag=True, help="Run bfloat16 pytests.")
 @click.option("--cccl", is_flag=True, help="Run CCCL (CUB) binding pytests.")
 @click.option("--all-tests", is_flag=True, help="Run all pytests.")
 def run(
     ast_canopy: bool,
     numbast: bool,
+    mlir: bool,
     bf16: bool,
     cccl: bool,
     all_tests: bool,
@@ -54,7 +56,7 @@ def run(
     package. `--all-tests` option is mutually exclusive to all other options.
     """
     if all_tests:
-        if any([ast_canopy, numbast, bf16, cccl]):
+        if any([ast_canopy, numbast, mlir, bf16, cccl]):
             raise ValueError(
                 "`all_tests` and any subpackage specs are mutual exclusive."
             )
@@ -63,6 +65,8 @@ def run(
         run_pytest("ast_canopy", ["ast_canopy/"])
     if all_tests or numbast:
         run_pytest("numbast", ["numbast/"], [f"--ignore={MLIR_TESTS_DIR}"])
+    if all_tests or mlir:
+        run_pytest("numbast_mlir", [MLIR_TESTS_DIR])
     if all_tests or bf16:
         run_pytest(
             "bf16",

--- a/ci/test_conda_python.sh
+++ b/ci/test_conda_python.sh
@@ -30,16 +30,13 @@ TEST_ENV_PACKAGES=(
   cuda-nvrtc
   cuda-cudart-dev
   python=${RAPIDS_PY_VERSION}
+  pip
   cffi
   ast_canopy="${PROJECT_VERSION}=*g${GIT_DESCRIBE_HASH}*"
   numbast="${PROJECT_VERSION}=*g${GIT_DESCRIBE_HASH}*"
 )
 
-if [[ "${TEST_BACKEND}" == "mlir" ]]; then
-  TEST_ENV_PACKAGES+=(
-    numba-cuda-mlir
-  )
-else
+if [[ "${TEST_BACKEND}" == "numba-cuda" ]]; then
   TEST_ENV_PACKAGES+=(
     "numba-cuda>=0.25.0"
     numbast-extensions="${PROJECT_VERSION}=*g${GIT_DESCRIBE_HASH}*"
@@ -50,13 +47,23 @@ rapids-mamba-retry create -n test "${TEST_ENV_PACKAGES[@]}"
 
 if [[ "${TEST_BACKEND}" == "mlir" ]]; then
   rapids-logger "Removing numba-cuda from MLIR test environment"
-  conda remove -n test --force -y numba-cuda
+  if conda list -n test numba-cuda | grep -E '^numba-cuda[[:space:]]'; then
+    conda remove -n test --force -y numba-cuda
+  fi
 fi
 
 # Temporarily allow unbound variables for conda activation.
 set +u
 conda activate test
 set -u
+
+if [[ "${TEST_BACKEND}" == "mlir" ]]; then
+  rapids-logger "Installing numba-cuda-mlir with pip"
+  python -m pip install numba-cuda-mlir
+  if python -m pip show numba-cuda; then
+    python -m pip uninstall -y numba-cuda
+  fi
+fi
 
 rapids-print-env
 

--- a/ci/test_conda_python.sh
+++ b/ci/test_conda_python.sh
@@ -8,28 +8,51 @@ set -euo pipefail
 
 rapids-logger "Starting Conda Package Test"
 
+TEST_BACKEND=${TEST_BACKEND:-numba-cuda}
+if [[ "${TEST_BACKEND}" != "numba-cuda" ]] && [[ "${TEST_BACKEND}" != "mlir" ]]; then
+  echo "Unsupported TEST_BACKEND='${TEST_BACKEND}'. Expected 'numba-cuda' or 'mlir'."
+  exit 1
+fi
+
 GIT_DESCRIBE_TAG=$(git describe --abbrev=0)
 PROJECT_VERSION=${GIT_DESCRIBE_TAG:1}
 GIT_DESCRIBE_HASH=$(git rev-parse --short HEAD)
 
 rapids-logger "Creating Test Environment"
 # TODO: replace this with rapids-dependency-file-generator
-rapids-mamba-retry create -n test \
-  -c `pwd`/conda-repo \
-  click \
-  pytest \
-  "clangdev>=18,<22.0" \
-  cuda-nvcc \
-  cuda-version=${RAPIDS_CUDA_VERSION%.*} \
-  cuda-nvrtc \
-  numba >=0.59 \
-  "numba-cuda>=0.25.0" \
-  cuda-cudart-dev \
-  python=${RAPIDS_PY_VERSION} \
-  cffi \
-  ast_canopy="${PROJECT_VERSION}=*g${GIT_DESCRIBE_HASH}*" \
-  numbast="${PROJECT_VERSION}=*g${GIT_DESCRIBE_HASH}*" \
-  numbast-extensions="${PROJECT_VERSION}=*g${GIT_DESCRIBE_HASH}*"
+TEST_ENV_PACKAGES=(
+  -c "$(pwd)/conda-repo"
+  click
+  pytest
+  "clangdev>=18,<22.0"
+  cuda-nvcc
+  cuda-version=${RAPIDS_CUDA_VERSION%.*}
+  cuda-nvrtc
+  "numba>=0.59"
+  cuda-cudart-dev
+  python=${RAPIDS_PY_VERSION}
+  cffi
+  ast_canopy="${PROJECT_VERSION}=*g${GIT_DESCRIBE_HASH}*"
+  numbast="${PROJECT_VERSION}=*g${GIT_DESCRIBE_HASH}*"
+)
+
+if [[ "${TEST_BACKEND}" == "mlir" ]]; then
+  TEST_ENV_PACKAGES+=(
+    numba-cuda-mlir
+  )
+else
+  TEST_ENV_PACKAGES+=(
+    "numba-cuda>=0.25.0"
+    numbast-extensions="${PROJECT_VERSION}=*g${GIT_DESCRIBE_HASH}*"
+  )
+fi
+
+rapids-mamba-retry create -n test "${TEST_ENV_PACKAGES[@]}"
+
+if [[ "${TEST_BACKEND}" == "mlir" ]]; then
+  rapids-logger "Removing numba-cuda from MLIR test environment"
+  conda remove -n test --force -y numba-cuda
+fi
 
 # Temporarily allow unbound variables for conda activation.
 set +u
@@ -41,15 +64,25 @@ rapids-print-env
 rapids-logger "Check GPU usage"
 nvidia-smi
 
-rapids-logger "Show Numba system info"
-python -m numba --sysinfo
+if [[ "${TEST_BACKEND}" == "mlir" ]]; then
+  rapids-logger "Check MLIR test dependencies"
+  python -c "import numba_cuda_mlir"
+  conda list numba-cuda | grep -E '^numba-cuda[[:space:]]' && exit 1 || true
+else
+  rapids-logger "Show Numba system info"
+  python -m numba --sysinfo
+fi
 
 EXITCODE=0
 trap "EXITCODE=1" ERR
 set +e
 
 rapids-logger "Run Tests"
-python ci/run_tests.py --ast-canopy --numbast --cccl
+if [[ "${TEST_BACKEND}" == "mlir" ]]; then
+  python ci/run_tests.py --ast-canopy --mlir
+else
+  python ci/run_tests.py --ast-canopy --numbast --cccl
+fi
 
 rapids-logger "Test script exiting with value: $EXITCODE"
 exit ${EXITCODE}

--- a/ci/test_conda_python.sh
+++ b/ci/test_conda_python.sh
@@ -58,6 +58,8 @@ conda activate test
 set -u
 
 if [[ "${TEST_BACKEND}" == "mlir" ]]; then
+  export LD_LIBRARY_PATH="${CONDA_PREFIX}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+
   rapids-logger "Installing numba-cuda-mlir with pip"
   python -m pip install numba-cuda-mlir
   if python -m pip show numba-cuda; then

--- a/ci/test_conda_python.sh
+++ b/ci/test_conda_python.sh
@@ -28,7 +28,6 @@ TEST_ENV_PACKAGES=(
   cuda-nvcc
   cuda-version=${RAPIDS_CUDA_VERSION%.*}
   cuda-nvrtc
-  "numba>=0.59"
   cuda-cudart-dev
   python=${RAPIDS_PY_VERSION}
   cffi

--- a/numbast/pyproject.toml
+++ b/numbast/pyproject.toml
@@ -39,7 +39,7 @@ issues = "https://github.com/NVIDIA/numbast/issues"
 [project.optional-dependencies]
 dev = ["ruff"]
 docs = ["sphinx>=7.0", "sphinx-copybutton>=0.5.2"]
-mlir = ["numba-cuda-mlir", "nvidia-cuda-nvrtc"]
+mlir = ["numba-cuda-mlir", "cuda-toolkit[nvrtc]"]
 test-cu12 = [
   "pytest",
   "cffi",
@@ -49,24 +49,23 @@ test-cu12 = [
 test-cu12-mlir = [
   "pytest",
   "cffi",
+  "cuda-toolkit[nvrtc]==12.9.*",
   "cuda-core>=0.7.0,<2.0.0",
   "numba-cuda-mlir",
-  "nvidia-cuda-nvrtc",
 ]
 test-cu13 = [
   "pytest",
   "cffi",
-  "cuda-toolkit[cudart,crt,curand,cccl,nvcc]==13.*",
+  "cuda-toolkit[cudart,crt,curand,cccl,nvcc]==13.2.*",
   "cuda-core>=0.7.0,<2.0.0",
   "numba-cuda[cu13]>=0.25.0",
 ]
 test-cu13-mlir = [
   "pytest",
   "cffi",
-  "cuda-toolkit[cudart,crt,curand,cccl,nvcc]==13.*",
+  "cuda-toolkit[cudart,crt,curand,cccl,nvcc,nvrtc]==13.2.*",
   "cuda-core>=0.7.0,<2.0.0",
   "numba-cuda-mlir",
-  "nvidia-cuda-nvrtc",
 ]
 
 

--- a/numbast/pyproject.toml
+++ b/numbast/pyproject.toml
@@ -39,7 +39,7 @@ issues = "https://github.com/NVIDIA/numbast/issues"
 [project.optional-dependencies]
 dev = ["ruff"]
 docs = ["sphinx>=7.0", "sphinx-copybutton>=0.5.2"]
-mlir = ["numba-cuda-mlir"]
+mlir = ["numba-cuda-mlir", "nvidia-cuda-nvrtc"]
 test-cu12 = [
   "pytest",
   "cffi",
@@ -51,6 +51,7 @@ test-cu12-mlir = [
   "cffi",
   "cuda-core>=0.7.0,<2.0.0",
   "numba-cuda-mlir",
+  "nvidia-cuda-nvrtc",
 ]
 test-cu13 = [
   "pytest",
@@ -65,6 +66,7 @@ test-cu13-mlir = [
   "cuda-toolkit[cudart,crt,curand,cccl,nvcc]==13.*",
   "cuda-core>=0.7.0,<2.0.0",
   "numba-cuda-mlir",
+  "nvidia-cuda-nvrtc",
 ]
 
 

--- a/numbast/pyproject.toml
+++ b/numbast/pyproject.toml
@@ -51,7 +51,6 @@ test-cu12-mlir = [
   "cffi",
   "cuda-toolkit[nvrtc]==12.9.*",
   "cuda-core>=0.7.0,<2.0.0",
-  "numba-cuda-mlir",
 ]
 test-cu13 = [
   "pytest",
@@ -65,7 +64,6 @@ test-cu13-mlir = [
   "cffi",
   "cuda-toolkit[cudart,crt,curand,cccl,nvcc,nvrtc]==13.2.*",
   "cuda-core>=0.7.0,<2.0.0",
-  "numba-cuda-mlir",
 ]
 
 

--- a/numbast/pyproject.toml
+++ b/numbast/pyproject.toml
@@ -39,7 +39,7 @@ issues = "https://github.com/NVIDIA/numbast/issues"
 [project.optional-dependencies]
 dev = ["ruff"]
 docs = ["sphinx>=7.0", "sphinx-copybutton>=0.5.2"]
-mlir = ["numba-cuda-mlir", "cuda-toolkit[nvrtc]"]
+mlir = ["numba-cuda-mlir", "cuda-toolkit[nvjitlink,nvrtc]"]
 test-cu12 = [
   "pytest",
   "cffi",
@@ -49,7 +49,7 @@ test-cu12 = [
 test-cu12-mlir = [
   "pytest",
   "cffi",
-  "cuda-toolkit[nvrtc]==12.9.*",
+  "cuda-toolkit[nvjitlink,nvrtc]==12.9.*",
   "cuda-core>=0.7.0,<2.0.0",
 ]
 test-cu13 = [
@@ -62,7 +62,7 @@ test-cu13 = [
 test-cu13-mlir = [
   "pytest",
   "cffi",
-  "cuda-toolkit[cudart,crt,curand,cccl,nvcc,nvrtc]==13.2.*",
+  "cuda-toolkit[cudart,crt,curand,cccl,nvcc,nvjitlink,nvrtc]==13.2.*",
   "cuda-core>=0.7.0,<2.0.0",
 ]
 

--- a/numbast/pyproject.toml
+++ b/numbast/pyproject.toml
@@ -39,11 +39,18 @@ issues = "https://github.com/NVIDIA/numbast/issues"
 [project.optional-dependencies]
 dev = ["ruff"]
 docs = ["sphinx>=7.0", "sphinx-copybutton>=0.5.2"]
+mlir = ["numba-cuda-mlir"]
 test-cu12 = [
   "pytest",
   "cffi",
   "cuda-core>=0.7.0,<2.0.0",
   "numba-cuda[cu12]>=0.25.0",
+]
+test-cu12-mlir = [
+  "pytest",
+  "cffi",
+  "cuda-core>=0.7.0,<2.0.0",
+  "numba-cuda-mlir",
 ]
 test-cu13 = [
   "pytest",
@@ -51,6 +58,13 @@ test-cu13 = [
   "cuda-toolkit[cudart,crt,curand,cccl,nvcc]==13.*",
   "cuda-core>=0.7.0,<2.0.0",
   "numba-cuda[cu13]>=0.25.0",
+]
+test-cu13-mlir = [
+  "pytest",
+  "cffi",
+  "cuda-toolkit[cudart,crt,curand,cccl,nvcc]==13.*",
+  "cuda-core>=0.7.0,<2.0.0",
+  "numba-cuda-mlir",
 ]
 
 

--- a/numbast/src/numbast/__init__.py
+++ b/numbast/src/numbast/__init__.py
@@ -1,30 +1,82 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-import numba
+from __future__ import annotations
 
-from numbast.struct import bind_cxx_struct, bind_cxx_structs
-from numbast.class_template import (
-    bind_cxx_class_template_specialization,
-    bind_cxx_class_template,
-    bind_cxx_class_templates,
-    clear_concrete_type_caches,
-)
-from numbast.function import bind_cxx_function, bind_cxx_functions
-from numbast.function_template import (
-    bind_cxx_function_template,
-    bind_cxx_function_templates,
-)
-from numbast.enum import bind_cxx_enum, bind_cxx_enums
-from numbast.shim_writer import MemoryShimWriter, FileShimWriter
+from importlib import import_module
+from importlib import metadata
 
-import importlib.metadata
+try:
+    __version__ = metadata.version("numbast")
+except metadata.PackageNotFoundError:
+    __version__ = "0+unknown"
 
-__version__ = importlib.metadata.version("numbast")
+_LAZY_ATTRS = {
+    "bind_cxx_enum": ("numbast.enum", "bind_cxx_enum"),
+    "bind_cxx_enums": ("numbast.enum", "bind_cxx_enums"),
+    "bind_cxx_function": ("numbast.function", "bind_cxx_function"),
+    "bind_cxx_functions": ("numbast.function", "bind_cxx_functions"),
+    "bind_cxx_function_template": (
+        "numbast.function_template",
+        "bind_cxx_function_template",
+    ),
+    "bind_cxx_function_templates": (
+        "numbast.function_template",
+        "bind_cxx_function_templates",
+    ),
+    "bind_cxx_struct": ("numbast.struct", "bind_cxx_struct"),
+    "bind_cxx_structs": ("numbast.struct", "bind_cxx_structs"),
+    "bind_cxx_class_template_specialization": (
+        "numbast.class_template",
+        "bind_cxx_class_template_specialization",
+    ),
+    "bind_cxx_class_template": (
+        "numbast.class_template",
+        "bind_cxx_class_template",
+    ),
+    "bind_cxx_class_templates": (
+        "numbast.class_template",
+        "bind_cxx_class_templates",
+    ),
+    "clear_concrete_type_caches": (
+        "numbast.class_template",
+        "clear_concrete_type_caches",
+    ),
+    "MemoryShimWriter": ("numbast.shim_writer", "MemoryShimWriter"),
+    "FileShimWriter": ("numbast.shim_writer", "FileShimWriter"),
+}
 
-major, minor, *_ = numba.__version__.split(".")
-if int(minor) < 59:
-    raise RuntimeError("Numba version >= 0.59rc1 is required")
+_numba_version_checked = False
+
+
+def _ensure_supported_numba() -> None:
+    global _numba_version_checked
+    if _numba_version_checked:
+        return
+
+    import numba
+
+    _major, minor, *_ = numba.__version__.split(".")
+    if int(minor) < 59:
+        raise RuntimeError("Numba version >= 0.59rc1 is required")
+
+    _numba_version_checked = True
+
+
+def __getattr__(name: str):
+    if name not in _LAZY_ATTRS:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    _ensure_supported_numba()
+    module_name, attr_name = _LAZY_ATTRS[name]
+    attr = getattr(import_module(module_name), attr_name)
+    globals()[name] = attr
+    return attr
+
+
+def __dir__():
+    return sorted({*globals(), *_LAZY_ATTRS})
+
 
 __all__ = [
     "__version__",

--- a/numbast/src/numbast/__init__.py
+++ b/numbast/src/numbast/__init__.py
@@ -46,28 +46,11 @@ _LAZY_ATTRS = {
     "FileShimWriter": ("numbast.shim_writer", "FileShimWriter"),
 }
 
-_numba_version_checked = False
-
-
-def _ensure_supported_numba() -> None:
-    global _numba_version_checked
-    if _numba_version_checked:
-        return
-
-    import numba
-
-    _major, minor, *_ = numba.__version__.split(".")
-    if int(minor) < 59:
-        raise RuntimeError("Numba version >= 0.59rc1 is required")
-
-    _numba_version_checked = True
-
 
 def __getattr__(name: str):
     if name not in _LAZY_ATTRS:
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
-    _ensure_supported_numba()
     module_name, attr_name = _LAZY_ATTRS[name]
     attr = getattr(import_module(module_name), attr_name)
     globals()[name] = attr

--- a/numbast/src/numbast/experimental/mlir/tests/conftest.py
+++ b/numbast/src/numbast/experimental/mlir/tests/conftest.py
@@ -2,7 +2,8 @@ import pytest
 
 import os
 
-import ast_canopy
+from ast_canopy import parse_declarations_from_source
+from numba_cuda_mlir import cuda
 
 
 @pytest.fixture(scope="session")
@@ -12,6 +13,9 @@ def decl_of():
 
     def _decl(file_name: str):
         path = _path(file_name)
-        return ast_canopy.parse_decl_only_from_src_current_sm(path), path
+        major, minor = cuda.get_current_device().compute_capability
+        return parse_declarations_from_source(
+            path, [path], f"sm_{major}{minor}"
+        ), path
 
     return _decl

--- a/numbast/src/numbast/experimental/mlir/tools/tests/test_symbol_exposure.py
+++ b/numbast/src/numbast/experimental/mlir/tools/tests/test_symbol_exposure.py
@@ -5,7 +5,7 @@ import os
 import subprocess
 import sys
 
-from cuda.core.experimental import Device
+from cuda.core import Device
 
 dev = Device(0)
 cc = dev.compute_capability

--- a/numbast/src/numbast/tests/test_package_init.py
+++ b/numbast/src/numbast/tests/test_package_init.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import subprocess
+import sys
+import textwrap
+
+
+def test_experimental_import_does_not_load_numba_cuda_backend():
+    script = textwrap.dedent(
+        """
+        import sys
+
+        import numbast.experimental
+
+        eager_modules = {
+            "numbast.class_template",
+            "numbast.enum",
+            "numbast.function",
+            "numbast.function_template",
+            "numbast.shim_writer",
+            "numbast.struct",
+        }
+        loaded = eager_modules.intersection(sys.modules)
+        assert not loaded, sorted(loaded)
+        assert numbast.__version__
+        assert "bind_cxx_struct" in numbast.__all__
+        """
+    )
+    subprocess.run([sys.executable, "-c", script], check=True)


### PR DESCRIPTION
Summary:
- Add changed-path detection so PR CI can run Numba-CUDA tests, MLIR tests, or both based on touched paths.
- Split conda and wheel test paths for Numba-CUDA and MLIR, with MLIR jobs installing numba-cuda-mlir and explicitly removing numba-cuda from that environment.
- Run ast_canopy in the MLIR conda path, skip CCCL there, and treat shared routing/config files as touching both test paths.

Testing:
- python -m py_compile ci/detect_test_paths.py ci/run_tests.py
- bash -n ci/test_conda_python.sh
- Parsed updated workflow YAML files with PyYAML
- Parsed numbast/pyproject.toml with tomllib
- python ci/detect_test_paths.py --base public/main --head HEAD
- env PYTHONPATH=numbast/src:ast_canopy python -m pytest numbast/src/numbast/tools/tests/test_mlir_backend_routing.py numbast/src/numbast/tools/tests/test_config_schema_docs.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced MLIR backend support as an alternative to Numba-CUDA for testing and deployment
  * Implemented lazy module attribute loading for improved package import performance

* **Chores**
  * Restructured CI pipelines to support backend-specific test execution
  * Enhanced test infrastructure with automatic change detection for targeted test runs

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/numbast/pull/363?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->