### PR TITLE
[codex] add numba-cuda-mlir support guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@
 
 An automated pipeline to parse CUDA C++ headers and generate Numba-compatible Python bindings.
 
+## Announcement
+
+Numbast now supports generating bindings for the
+[numba-cuda-mlir](https://nvidia.github.io/numba-cuda-mlir/latest/) backend.
+See [Numba-CUDA-MLIR support](https://nvidia.github.io/numbast/latest/numba_cuda_mlir.html)
+for backend differences and migration steps.
+
 Please visit the documentation site to get started:
 
 - [Overview](https://nvidia.github.io/numbast/latest/overview.html)

--- a/docs/source/generated/static_binding_schema_reference.rst
+++ b/docs/source/generated/static_binding_schema_reference.rst
@@ -238,6 +238,23 @@ Optional keys
         teardown: 'lambda mod: print(''unloaded'', mod)'
 
 
+``Module Link Variables Used`` : ``array``
+   Experimental MLIR-backend-only linker metadata variables to mark as used. Requires ``MLIR Backend: true``.
+
+   Default: ``[]``.
+
+   Constraints:
+
+   - Item type: ``string``
+
+   Example:
+
+   .. code-block:: yaml
+
+      Module Link Variables Used:
+      - __numbast_module_used
+
+
 ``Skip Prefix`` : ``string | null``
    Skip generating bindings for functions whose names start with this prefix.
 
@@ -276,6 +293,19 @@ Optional keys
         my_function:
           result: out_ptr
           0: in
+
+
+``MLIR Backend`` : ``boolean``
+   Route static binding generation to the experimental ``numbast.experimental.mlir`` backend. This requires a
+   user-provided ``numba_cuda_mlir`` installation.
+
+   Default: ``false``.
+
+   Example:
+
+   .. code-block:: yaml
+
+      MLIR Backend: true
 
 
 Optional nested keys
@@ -578,6 +608,16 @@ Raw schema
            description: Python expression for teardown callback.
            examples:
              - "lambda mod: print('unloaded', mod)"
+     Module Link Variables Used:
+       type: array
+       default: []
+       items:
+         type: string
+       description: >
+         Experimental MLIR-backend-only linker metadata variables to mark as used. Requires ``MLIR Backend: true``.
+
+       examples:
+         - - "__numbast_module_used"
      Skip Prefix:
        type: [string, "null"]
        default: null
@@ -615,3 +655,12 @@ Raw schema
                    type: string
                    enum: ["in", "inout_ptr", "out_ptr", "out_return"]
                required: ["intent"]
+     MLIR Backend:
+       type: boolean
+       default: false
+       description: >
+         Route static binding generation to the experimental ``numbast.experimental.mlir`` backend. This requires a
+         user-provided ``numba_cuda_mlir`` installation.
+
+       examples:
+         - true

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,12 +1,23 @@
 Numbast Documentation
 =====================
 
+Announcement
+------------
+
+.. admonition:: Numba-CUDA-MLIR binding generation
+
+   Numbast now supports generating bindings for the
+   `numba-cuda-mlir <https://nvidia.github.io/numba-cuda-mlir/latest/>`__
+   backend. See :doc:`numba_cuda_mlir` for the backend differences and the
+   migration steps for dynamic and static binding generation.
+
 .. toctree::
    :maxdepth: 2
    :caption: Contents
 
    overview
    quickstart
+   numba_cuda_mlir
    install
    static
    dynamic

--- a/docs/source/numba_cuda_mlir.rst
+++ b/docs/source/numba_cuda_mlir.rst
@@ -1,0 +1,98 @@
+Numba-CUDA-MLIR support
+=======================
+
+Numbast can generate bindings for both the default
+`Numba-CUDA <https://nvidia.github.io/numba-cuda/>`__ backend and the
+experimental
+`numba-cuda-mlir <https://nvidia.github.io/numba-cuda-mlir/latest/>`__
+backend. The CUDA C++ parsing workflow is the same for both backends; the
+differences are the Python import namespace, runtime dependency, and static
+binding configuration.
+
+Backend differences
+-------------------
+
+.. list-table::
+   :header-rows: 1
+
+   * - Area
+     - Numba-CUDA
+     - numba-cuda-mlir
+   * - Dynamic Numbast imports
+     - Import binding helpers from top-level ``numbast``.
+     - Import binding helpers from ``numbast.experimental.mlir``.
+   * - Static binding generation
+     - Use the default static generator configuration.
+     - Add ``MLIR Backend: true`` to the static binding config.
+   * - Generated module target
+     - Generated bindings target the ``numba-cuda`` runtime.
+     - Generated bindings target the ``numba-cuda-mlir`` runtime.
+   * - Dependency setup
+     - Install Numbast with the default ``numba-cuda`` dependency.
+     - Install ``numba-cuda-mlir`` in the environment used to generate and run
+       the bindings.
+
+Dynamic binding generation
+--------------------------
+
+For dynamic binding generation, change imports from top-level ``numbast`` to
+``numbast.experimental.mlir``. The Numbast helper names remain the same.
+
+Before:
+
+.. code-block:: python
+
+   from numbast import bind_cxx_function, bind_cxx_struct, MemoryShimWriter
+
+After:
+
+.. code-block:: python
+
+   from numbast.experimental.mlir import (
+       bind_cxx_function,
+       bind_cxx_struct,
+       MemoryShimWriter,
+   )
+
+Use ``numba_cuda_mlir`` types, models, and CUDA entry points with the generated
+bindings.
+
+.. code-block:: python
+
+   from numba_cuda_mlir import cuda, types
+   from numba_cuda_mlir.models import PrimitiveModel
+
+
+Static binding generation
+-------------------------
+
+For static binding generation, add the ``MLIR Backend`` entry to the same
+config file you use with the default Numbast CLI.
+
+.. code-block:: yaml
+
+   Entry Point: /path/to/library/header.hpp
+   File List:
+     - /path/to/library/header.hpp
+   GPU Arch: ["sm_80"]
+
+   MLIR Backend: true
+
+Then run the standard Numbast static binding generator:
+
+.. code-block:: bash
+
+   python -m numbast --cfg-path config.yml --output-dir ./output
+
+With ``MLIR Backend: true``, the CLI routes generation through
+``numbast.experimental.mlir`` and writes a module for ``numba-cuda-mlir``.
+
+Notes
+-----
+
+- The MLIR backend is experimental and is not re-exported from top-level
+  ``numbast``.
+- The environment that generates or imports MLIR-backed bindings must provide
+  ``numba_cuda_mlir``.
+- Backend-specific static config keys that mention MLIR require
+  ``MLIR Backend: true``.

--- a/docs/source/numba_cuda_mlir.rst
+++ b/docs/source/numba_cuda_mlir.rst
@@ -29,11 +29,18 @@ Backend differences
      - Generated bindings target the ``numba-cuda-mlir`` runtime.
    * - Dependency setup
      - Install Numbast with the default ``numba-cuda`` dependency.
-     - Install ``numba-cuda-mlir`` in the environment used to generate and run
-       the bindings.
+     - For dynamic binding generation, install Numbast with the ``mlir`` extra
+       so ``numba-cuda-mlir`` is available.
 
 Dynamic binding generation
 --------------------------
+
+If you intend to use dynamic binding generation with ``numba-cuda-mlir``,
+install Numbast with the ``mlir`` extra:
+
+.. code-block:: bash
+
+   pip install "numbast[mlir]"
 
 For dynamic binding generation, change imports from top-level ``numbast`` to
 ``numbast.experimental.mlir``. The Numbast helper names remain the same.

--- a/docs/source/static.rst
+++ b/docs/source/static.rst
@@ -28,10 +28,9 @@ drift between implementation and documentation.
 For details on ``Function Argument Intents`` semantics and generated signatures,
 see :doc:`/argument_intents`.
 
-The experimental ``numbast-mlir`` backend is selected with
-``MLIR Backend: true`` and is imported from ``numbast.experimental.mlir``. It
-requires a user-provided ``numba_cuda_mlir`` installation; the default Numbast
-test environments do not install or run it yet.
+The experimental ``numba-cuda-mlir`` backend is selected with
+``MLIR Backend: true`` and is imported from ``numbast.experimental.mlir``. See
+:doc:`numba_cuda_mlir` for the backend differences and migration guidance.
 
 Config example:
 


### PR DESCRIPTION
## Summary

- Add a homepage announcement for Numbast support for generating `numba-cuda-mlir` bindings.
- Add a new `numba_cuda_mlir` documentation page covering the dynamic import migration and `MLIR Backend: true` static config entry.
- Update the static binding docs to link to the new backend guidance, and refresh the generated static binding schema reference so the MLIR backend config appears there.
- Add the same announcement to the repository README without adding it to the general README docs link list.

## Validation

- `git diff --check`
- `pixi run -e test-cu13 build-docs latest-only`
- Commit hooks: `doc8`, `rstcheck`, `codespell`, whitespace checks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added announcement and comprehensive documentation for numba-cuda-mlir backend support
  * Documented setup requirements, backend differences, and step-by-step instructions for dynamic and static binding generation with the MLIR backend

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/numbast/pull/364?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->