### PR TITLE
Remove direct numba imports from MLIR backend

### DIFF
--- a/numbast/src/numbast/experimental/mlir/class_template.py
+++ b/numbast/src/numbast/experimental/mlir/class_template.py
@@ -14,9 +14,8 @@ from ast_canopy import pylibastcanopy
 import numba_cuda_mlir.types as sttypes
 import numba_cuda_mlir.types as nbtypes
 from numba_cuda_mlir.numba_cuda import types as cuda_nbtypes
-from numba.core import types as legacy_types
-from numba.core.extending import (
-    register_model as legacy_register_model,
+from numba_cuda_mlir.numba_cuda.extending import (
+    register_model as cuda_register_model,
 )
 from numba_cuda_mlir.numba_cuda.typing import signature as nb_signature
 from numba_cuda_mlir.numba_cuda.typing.templates import (
@@ -93,18 +92,18 @@ lower_getattr = lowering_registry.lower_getattr
 
 
 def register_model(type_cls):
-    """Register data-model handlers for both MLIR and legacy contexts."""
+    """Register data-model handlers for both MLIR and CUDA contexts."""
     mlir_decorator = mlir_register_model(type_cls)
-    legacy_decorator = (
-        legacy_register_model(type_cls)
-        if issubclass(type_cls, legacy_types.Type)
+    cuda_decorator = (
+        cuda_register_model(type_cls)
+        if issubclass(type_cls, cuda_nbtypes.Type)
         else None
     )
 
     def _decorator(model_cls):
         model_cls = mlir_decorator(model_cls)
-        if legacy_decorator is not None:
-            model_cls = legacy_decorator(model_cls)
+        if cuda_decorator is not None:
+            model_cls = cuda_decorator(model_cls)
         return model_cls
 
     return _decorator

--- a/numbast/src/numbast/experimental/mlir/static/renderer.py
+++ b/numbast/src/numbast/experimental/mlir/static/renderer.py
@@ -161,7 +161,7 @@ def _numbast_link_shim(builder, shim_obj):
     """Vector type symbols (e.g. float32x4) to emit as VectorType(elt, n). Handled in _get_rendered_imports."""
 
     _imported_numba_types = set()
-    """Set of imported numba type in strings."""
+    """Set of imported numba-cuda-mlir type strings."""
 
     MemoryShimWriterTemplate = """
 c_ext_shim_source = CUSource(\"""{shim_funcs}\""")
@@ -170,7 +170,7 @@ c_ext_shim_source = CUSource(\"""{shim_funcs}\""")
     ShimFunctions: list[str] = []
 
     _imported_numba_types = set()
-    """Set of imported numba type in strings."""
+    """Set of imported numba-cuda-mlir type strings."""
 
     includes_template = "#include <{header_path}>"
     """Template for including a header file."""
@@ -198,9 +198,8 @@ c_ext_shim_source = CUSource(\"""{shim_funcs}\""")
             decl: The parsed declaration object the renderer will use to produce code.
 
         Notes:
-            This constructor records "import numba" and "import io" in the class-level Imports set as part of instance initialization.
+            This constructor records "import io" in the class-level Imports set as part of instance initialization.
         """
-        self.Imports.add("import numba")
         self.Imports.add("import io")
         self._decl = decl
 

--- a/numbast/src/numbast/experimental/mlir/static/struct.py
+++ b/numbast/src/numbast/experimental/mlir/static/struct.py
@@ -9,7 +9,7 @@ import warnings
 
 from numba_cuda_mlir.types import Type
 from numba_cuda_mlir.models import StructModel, PrimitiveModel
-from numba.core.datamodel.models import (
+from numba_cuda_mlir.numba_cuda.datamodel.models import (
     StructModel as NumbaStructModel,
     PrimitiveModel as NumbaPrimitiveModel,
 )

--- a/numbast/src/numbast/experimental/mlir/tools/static_binding_generator.py
+++ b/numbast/src/numbast/experimental/mlir/tools/static_binding_generator.py
@@ -13,8 +13,10 @@ import re
 import yaml
 
 from numba_cuda_mlir.numba_cuda.core import config
+from numba_cuda_mlir.numba_cuda.datamodel import (
+    models as cuda_datamodel_models,
+)
 import numba_cuda_mlir.types as mlir_types
-import numba.core.datamodel.models
 import numba_cuda_mlir.models as mlir_models
 
 from ast_canopy import parse_declarations_from_source
@@ -399,7 +401,7 @@ def _str_value_to_numba_datamodel(
 
     Resolution order:
       1. `numba_cuda_mlir.models`
-      2. `numba.core.datamodel.models`
+      2. `numba_cuda_mlir.numba_cuda.datamodel.models`
     """
     converted: dict[str, type] = {}
     for key, model_name in d.items():
@@ -407,11 +409,12 @@ def _str_value_to_numba_datamodel(
             converted[key] = getattr(mlir_models, model_name)
             continue
         try:
-            converted[key] = getattr(numba.core.datamodel.models, model_name)
+            converted[key] = getattr(cuda_datamodel_models, model_name)
         except AttributeError as exc:
             raise AttributeError(
                 f"Unknown data model '{model_name}'. "
-                "Tried numba_cuda_mlir.models and numba.core.datamodel.models."
+                "Tried numba_cuda_mlir.models and "
+                "numba_cuda_mlir.numba_cuda.datamodel.models."
             ) from exc
     return converted
 


### PR DESCRIPTION
## Summary
- replace direct MLIR backend imports from `numba.core` with `numba_cuda_mlir.numba_cuda` modules
- keep MLIR data-model resolution within `numba_cuda_mlir` namespaces
- remove the generated static-binding `import numba` leak so generated MLIR bindings no longer require external `numba`

## Validation
- `rg -n "^\\s*(import numba($|[ ,])|from numba(\\.| import))|numba\\.core" numbast/src/numbast/experimental/mlir`
- `rg -n "Imports\\.add\\(\\\"import numba\\\"|\\\"import numba\\\"|\x27import numba\x27|^\\s*import numba($|[ ,])|^\\s*from numba(\\.| import)" numbast/src/numbast/experimental/mlir`
- stubbed renderer import check confirms generated base imports include `import io` but not `import numba`
- `python -m py_compile numbast/src/numbast/experimental/mlir/static/renderer.py numbast/src/numbast/experimental/mlir/class_template.py numbast/src/numbast/experimental/mlir/static/struct.py numbast/src/numbast/experimental/mlir/tools/static_binding_generator.py`
- `git diff --check`

Note: a full local smoke import against the source checkout is blocked by missing built MLIR Python bindings in the local `numba-cuda-mlir` tree, not by a direct `numba` import.