### PR TITLE
Un-xfail `test_static_type_check`

### DIFF
--- a/numbast/src/numbast/experimental/mlir/static/tests/test_struct_static_bindings.py
+++ b/numbast/src/numbast/experimental/mlir/static/tests/test_struct_static_bindings.py
@@ -109,10 +109,6 @@ def test_myint_cast(decl, impl):
     assert arr.copy_to_host() == pytest.approx([42])
 
 
-@pytest.mark.xfail(
-    reason="numba-cuda-mlir does not support isinstance lowering for generated static types",
-    strict=True,
-)
 def test_static_type_check(decl, impl):
     MyInt = decl["MyInt"]
 


### PR DESCRIPTION
This pairs with https://github.com/NVIDIA/numba-cuda-mlir/pull/54, which makes this particular test now pass.