### PR TITLE
[codex] Handle CUDA inline hint in ast_canopy

### DIFF
--- a/ast_canopy/ast_canopy/api.py
+++ b/ast_canopy/ast_canopy/api.py
@@ -33,6 +33,11 @@ _CUDA_HEADER_PARSING_FLAGS: list[str] = [
     "-nocudalib",
 ]
 
+# CUDA accepts this inline hint spelling, but Clang does not predefine it.
+_CUDA_PARSER_COMPAT_DEFINES: list[str] = [
+    "__inline_hint__=",
+]
+
 
 def _get_shim_include_dir() -> str:
     """Return the absolute path to the local shim include directory"""
@@ -477,7 +482,9 @@ def parse_declarations_from_source(
 
     cuda_wrappers_dir = get_cuda_wrappers_include_dir(clang_resource_dir)
 
-    define_flags = [f"-D{define}" for define in defines]
+    define_flags = [
+        f"-D{define}" for define in [*_CUDA_PARSER_COMPAT_DEFINES, *defines]
+    ]
 
     # The include paths are ordered a below:
     # 1. clang resource file include directory (via -isystem flag)

--- a/ast_canopy/tests/data/inline_hint_macro_fix.cu
+++ b/ast_canopy/tests/data/inline_hint_macro_fix.cu
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+// All rights reserved. SPDX-License-Identifier: Apache-2.0
+
+#define NVSHMEMI_DEVICE_INLINE __inline_hint__
+
+__device__ NVSHMEMI_DEVICE_INLINE void inline_hint_void() {}
+
+__device__ NVSHMEMI_DEVICE_INLINE int inline_hint_int() { return 1; }

--- a/ast_canopy/tests/test_inline_hint_fix.py
+++ b/ast_canopy/tests/test_inline_hint_fix.py
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from ast_canopy import parse_declarations_from_source
+
+
+@pytest.fixture(scope="module")
+def sample_inline_hint_macro(data_folder):
+    return data_folder / "inline_hint_macro_fix.cu"
+
+
+def test_inline_hint_macro(sample_inline_hint_macro):
+    srcstr = str(sample_inline_hint_macro)
+
+    decls = parse_declarations_from_source(srcstr, [srcstr], "sm_80")
+    functions = {func.name: func for func in decls.functions}
+
+    assert functions["inline_hint_void"].return_type.name == "void"
+    assert functions["inline_hint_int"].return_type.name == "int"


### PR DESCRIPTION
## Summary

- Add an ast_canopy parser compatibility define for CUDA's `__inline_hint__` spelling.
- Add a focused regression source and unit test for NVSHMEM-style `NVSHMEMI_DEVICE_INLINE` expansion.
- Assert both `void` and `int` return types so parse failures do not silently degrade `void` declarations to `int`.

## Validation

- `PRE_COMMIT_HOME=/tmp/numbast-inline-hint-precommit pre-commit run --all-files`
- `PYTHONPATH=/tmp/numbast-inline-hint-pr/ast_canopy python -c "import sys; sys.meta_path=[finder for finder in sys.meta_path if finder.__class__.__module__ != '_ast_canopy_editable']; import pytest; sys.exit(pytest.main(['ast_canopy/tests/test_inline_hint_fix.py', 'ast_canopy/tests/test_command_invocation.py', '--import-mode=importlib']))"`
- `PYTHONPATH=/tmp/numbast-inline-hint-pr/ast_canopy python -c "import sys; sys.meta_path=[finder for finder in sys.meta_path if finder.__class__.__module__ != '_ast_canopy_editable']; import pytest; sys.exit(pytest.main(['ast_canopy/tests/test_inline_hint_fix.py', 'ast_canopy/tests/test_noinline_fix.py', 'ast_canopy/tests/test_attributes.py', 'ast_canopy/tests/test_parse_macro.py', '--import-mode=importlib']))"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CUDA parsing to include Clang-compatible inline-hint macro handling, ensuring device-side inline hint macros are recognized during declaration parsing.

* **Tests**
  * Added tests and sample CUDA source to verify correct parsing of inline-hint macros and validate returned function signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->