### PR TITLE
ci: run full tests for version bump PRs

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -58,8 +58,7 @@ jobs:
       build_type: pull-request
   test-conda-numba-cuda:
     name: Test Conda Python (Numba-CUDA)
-    # Temporarily disabled while the MLIR CI path is being stabilized.
-    if: false
+    if: needs.detect-changes.outputs.run_numba_cuda_tests == 'true'
     needs:
       - build-conda
       - detect-changes
@@ -89,8 +88,7 @@ jobs:
       build_type: pull-request
   test-wheels-numba-cuda:
     name: Test Wheels (Numba-CUDA)
-    # Temporarily disabled while the MLIR CI path is being stabilized.
-    if: false
+    if: needs.detect-changes.outputs.run_numba_cuda_tests == 'true'
     needs:
       - build-wheels
       - detect-changes

--- a/ci/detect_test_paths.py
+++ b/ci/detect_test_paths.py
@@ -11,7 +11,13 @@ from pathlib import Path
 
 MLIR_PREFIX = "numbast/src/numbast/experimental/mlir/"
 
-BOTH_TEST_PATHS = {
+RELEASE_METADATA_PATHS = {
+    "VERSION",
+    "docs/versions.json",
+    "docs/nv-versions.json",
+}
+
+BOTH_TEST_PATHS = RELEASE_METADATA_PATHS | {
     "numbast/src/numbast/__init__.py",
     "numbast/src/numbast/tools/static_binding_generator.py",
     "numbast/src/numbast/tools/static_binding_generator.schema.yaml",


### PR DESCRIPTION
## Summary
- Treat release metadata changes as full-suite PR triggers.
- Restore the Numba-CUDA PR jobs to use the changed-path detector output instead of being hard-skipped.

## Validation
- `python -c "from ci.detect_test_paths import classify_paths; print(classify_paths(['VERSION', 'docs/versions.json', 'docs/nv-versions.json']))"` -> `(True, True)`
- `python -c "from ci.detect_test_paths import classify_paths; print(classify_paths(['docs/source/install.rst']))"` -> `(True, False)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Re-enabled Numba-CUDA tests with conditional detection logic
  * Refactored test path configuration for improved release metadata handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->