### PR TITLE
Migrate scikit-build target configuration

### DIFF
--- a/ast_canopy/pyproject.toml
+++ b/ast_canopy/pyproject.toml
@@ -16,7 +16,7 @@ cu13 = ["cuda-toolkit[cudart, crt, curand, cccl]>=13.1,<14"]
 
 
 [tool.scikit-build]
-cmake.targets = ["pylibastcanopy"]
+build.targets = ["pylibastcanopy"]
 wheel.license-files = ["../LICENSE"]
 # Be explicit about shipping header shims in sdists so wheels built from sdist
 # (e.g., on PyPI) always contain these files.


### PR DESCRIPTION
## Summary

- migrate the ast_canopy scikit-build-core target setting from `cmake.targets` to `build.targets`
- retain the existing `pylibastcanopy` build target

## Root cause

Current CI resolves scikit-build-core 1.0.3, which rejects `cmake.targets` during package metadata generation and directs projects to use `build.targets`. This causes every Conda and wheel packaging job to fail before tests can run.

The configuration key predates the current backend behavior and is unrelated to the package source being built.

## Impact

This restores ast_canopy metadata and wheel configuration parsing with current scikit-build-core releases, unblocking downstream packaging and test jobs.

## Validation

- scikit-build-core 1.0.3 `get_requires_for_build_wheel()` — passed
- scikit-build-core 0.11.6 `get_requires_for_build_wheel()` — passed
- repository pre-commit hooks — passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package build configuration to ensure the intended native component is included during builds.
  * No changes to public APIs, functionality, or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->