### PR TITLE
Expose C linkage and variadic function metadata in AST Canopy

### DIFF
--- a/ast_canopy/ast_canopy/decl.py
+++ b/ast_canopy/ast_canopy/decl.py
@@ -259,6 +259,7 @@ class StructMethod(Function):
         mangled_name: str,
         attributes: str,
         parse_entry_point: str,
+        is_variadic: bool = False,
     ):
         super().__init__(
             name,
@@ -270,6 +271,7 @@ class StructMethod(Function):
             mangled_name,
             attributes,
             parse_entry_point,
+            is_variadic=is_variadic,
         )
         self.kind = kind
         self.is_move_constructor = is_move_constructor
@@ -302,6 +304,7 @@ class StructMethod(Function):
             c_obj.mangled_name,
             c_obj.attributes,
             parse_entry_point,
+            getattr(c_obj, "is_variadic", False),
         )
 
 

--- a/ast_canopy/ast_canopy/decl.py
+++ b/ast_canopy/ast_canopy/decl.py
@@ -77,6 +77,8 @@ class Function:
         mangled_name: str,
         attributes: str,
         parse_entry_point: str,
+        is_c_linkage: bool | None = None,
+        is_variadic: bool = False,
     ):
         self.name = name
         self.qual_name = qual_name
@@ -88,6 +90,8 @@ class Function:
         self.is_constexpr = is_constexpr
         self.mangled_name = mangled_name
         self.attributes = attributes
+        self.is_c_linkage = is_c_linkage
+        self.is_variadic = is_variadic
 
         self.parse_entry_point = parse_entry_point
 
@@ -169,6 +173,8 @@ class Function:
             c_obj.mangled_name,
             c_obj.attributes,
             parse_entry_point,
+            getattr(c_obj, "is_c_linkage", None),
+            getattr(c_obj, "is_variadic", False),
         )
 
 

--- a/ast_canopy/ast_canopy/decl.py
+++ b/ast_canopy/ast_canopy/decl.py
@@ -260,6 +260,7 @@ class StructMethod(Function):
         attributes: str,
         parse_entry_point: str,
         is_variadic: bool = False,
+        is_c_linkage: bool | None = None,
     ):
         super().__init__(
             name,
@@ -271,6 +272,7 @@ class StructMethod(Function):
             mangled_name,
             attributes,
             parse_entry_point,
+            is_c_linkage=is_c_linkage,
             is_variadic=is_variadic,
         )
         self.kind = kind
@@ -304,7 +306,8 @@ class StructMethod(Function):
             c_obj.mangled_name,
             c_obj.attributes,
             parse_entry_point,
-            getattr(c_obj, "is_variadic", False),
+            is_variadic=getattr(c_obj, "is_variadic", False),
+            is_c_linkage=getattr(c_obj, "is_c_linkage", None),
         )
 
 

--- a/ast_canopy/ast_canopy/pylibastcanopy.cpp
+++ b/ast_canopy/ast_canopy/pylibastcanopy.cpp
@@ -242,9 +242,11 @@ PYBIND11_MODULE(pylibastcanopy, m) {
               throw std::runtime_error(
                   "Invalid class template state during unpickle!");
             Function f = t[0].cast<Function>();
-            return Method{f.name,      f.return_type,
+            Method method{f.name,      f.return_type,
                           f.params,    f.exec_space,
                           f.qual_name, t[1].cast<method_kind>()};
+            method.is_variadic = f.is_variadic;
+            return method;
           }));
 
   py::class_<Record>(m, "Record")

--- a/ast_canopy/ast_canopy/pylibastcanopy.cpp
+++ b/ast_canopy/ast_canopy/pylibastcanopy.cpp
@@ -162,21 +162,28 @@ PYBIND11_MODULE(pylibastcanopy, m) {
       .def_readwrite("params", &Function::params)
       .def_readwrite("exec_space", &Function::exec_space)
       .def_readwrite("is_constexpr", &Function::is_constexpr)
+      .def_readwrite("is_c_linkage", &Function::is_c_linkage)
+      .def_readwrite("is_variadic", &Function::is_variadic)
       .def_readwrite("mangled_name", &Function::mangled_name)
       .def_readwrite("attributes", &Function::attributes)
       .def(py::pickle(
           [](const Function &f) {
             return py::make_tuple(f.name, f.return_type, f.params, f.exec_space,
-                                  f.qual_name);
+                                  f.qual_name, f.is_c_linkage, f.is_variadic);
           },
           [](py::tuple t) {
-            if (t.size() != 5)
+            if (t.size() != 5 && t.size() != 7)
               throw std::runtime_error(
                   "Invalid function state during unpickle!");
-            return Function{t[0].cast<std::string>(), t[1].cast<Type>(),
-                            t[2].cast<std::vector<ParamVar>>(),
-                            t[3].cast<execution_space>(),
-                            t[4].cast<std::string>()};
+            Function function{t[0].cast<std::string>(), t[1].cast<Type>(),
+                              t[2].cast<std::vector<ParamVar>>(),
+                              t[3].cast<execution_space>(),
+                              t[4].cast<std::string>()};
+            if (t.size() == 7) {
+              function.is_c_linkage = t[5].cast<bool>();
+              function.is_variadic = t[6].cast<bool>();
+            }
+            return function;
           }));
 
   py::class_<Template>(m, "Template")

--- a/ast_canopy/ast_canopy/pylibastcanopy.cpp
+++ b/ast_canopy/ast_canopy/pylibastcanopy.cpp
@@ -245,6 +245,7 @@ PYBIND11_MODULE(pylibastcanopy, m) {
             Method method{f.name,      f.return_type,
                           f.params,    f.exec_space,
                           f.qual_name, t[1].cast<method_kind>()};
+            method.is_c_linkage = f.is_c_linkage;
             method.is_variadic = f.is_variadic;
             return method;
           }));

--- a/ast_canopy/ast_canopy/pylibastcanopy.pyi
+++ b/ast_canopy/ast_canopy/pylibastcanopy.pyi
@@ -52,6 +52,8 @@ class Function:
     attributes: set[str]
     exec_space: execution_space
     is_constexpr: bool
+    is_c_linkage: bool
+    is_variadic: bool
     mangled_name: str
     name: str
     qual_name: str

--- a/ast_canopy/cpp/include/ast_canopy/ast_canopy.hpp
+++ b/ast_canopy/cpp/include/ast_canopy/ast_canopy.hpp
@@ -154,6 +154,8 @@ struct Function {
   std::vector<ParamVar> params;
   execution_space exec_space;
   bool is_constexpr;
+  bool is_c_linkage = false;
+  bool is_variadic = false;
   std::string mangled_name;
   std::set<std::string> attributes;
 };

--- a/ast_canopy/cpp/src/function.cpp
+++ b/ast_canopy/cpp/src/function.cpp
@@ -131,7 +131,8 @@ make_dependent_signature_fallback(const clang::FunctionDecl *FD,
 Function::Function(const clang::FunctionDecl *FD)
     : name(FD->getNameAsString()), qual_name(FD->getQualifiedNameAsString()),
       return_type(FD->getReturnType(), FD->getASTContext()),
-      is_constexpr(FD->isConstexpr()) {
+      is_constexpr(FD->isConstexpr()), is_c_linkage(FD->isExternC()),
+      is_variadic(FD->isVariadic()) {
   if (qual_name.empty()) {
     qual_name = name;
   }
@@ -150,7 +151,12 @@ Function::Function(const clang::FunctionDecl *FD)
   // the Clang Itanium mangler can segfault when asked to mangle types that
   // are still template-dependent (e.g. methods of uninstantiated class
   // templates such as Eigen::Matrix<Scalar_,...>).
-  if (has_dependent_signature(FD)) {
+  if (is_c_linkage) {
+    // C-linkage declarations are exported under their source spelling. Calling
+    // the Itanium mangler unconditionally produces a C++ symbol that does not
+    // exist in the object file.
+    mangled_name = name;
+  } else if (has_dependent_signature(FD)) {
     mangled_name = make_dependent_signature_fallback(FD, qual_name);
   } else {
     auto &context = FD->getASTContext();

--- a/ast_canopy/tests/data/sample_itanium_mangled_names.cu
+++ b/ast_canopy/tests/data/sample_itanium_mangled_names.cu
@@ -25,3 +25,6 @@ __device__ int inner_func(Foo a, Bar b) { return 0; }
 namespace ns2 {
 __device__ int inner_func(Foo a, Bar b) { return 0; }
 } // namespace ns2
+
+extern "C" __device__ int c_device_func(int value) { return value; }
+extern "C" int c_variadic_func(int value, ...);

--- a/ast_canopy/tests/data/sample_itanium_mangled_names.cu
+++ b/ast_canopy/tests/data/sample_itanium_mangled_names.cu
@@ -6,6 +6,7 @@
 struct Foo {
   __device__ Foo() = default;
   __device__ Foo(int a) : a(a) {}
+  __device__ int variadic_member(int value, ...);
   int a;
 };
 

--- a/ast_canopy/tests/test_mangled_name.py
+++ b/ast_canopy/tests/test_mangled_name.py
@@ -86,5 +86,8 @@ def test_variadic_member_function_metadata_survives_pickle(decls):
         method for method in foo.methods if method.name == "variadic_member"
     )
 
+    assert method.is_c_linkage is False
     assert method.is_variadic is True
-    assert pickle.loads(pickle.dumps(method)).is_variadic is True
+    restored = pickle.loads(pickle.dumps(method))
+    assert restored.is_c_linkage is False
+    assert restored.is_variadic is True

--- a/ast_canopy/tests/test_mangled_name.py
+++ b/ast_canopy/tests/test_mangled_name.py
@@ -1,4 +1,5 @@
 import os
+import pickle
 
 import pytest
 
@@ -13,6 +14,8 @@ def decls(data_folder):
         path,
         [path],
         "sm_80",
+        defines=["__device__=__attribute__((device))"],
+        cuda_header_mode=True,
     )
 
     return decls
@@ -23,7 +26,7 @@ def test_itanium_mangled_name(decls):
     functions = decls.functions
 
     assert len(structs) == 2
-    assert len(functions) == 4
+    assert len(functions) == 6
 
     assert structs[0].name == "Foo"
     assert structs[1].name == "Bar"
@@ -47,3 +50,31 @@ def test_itanium_mangled_name(decls):
     assert functions[1].mangled_name == "_ZplRK3BarS1_"
     assert functions[2].mangled_name == "_ZN3ns110inner_funcE3Foo3Bar"
     assert functions[3].mangled_name == "_ZN3ns210inner_funcE3Foo3Bar"
+
+
+def test_c_linkage_and_variadic_metadata(decls):
+    functions = {function.name: function for function in decls.functions}
+
+    c_device = functions["c_device_func"]
+    assert c_device.is_c_linkage is True
+    assert c_device.is_variadic is False
+    assert c_device.mangled_name == "c_device_func"
+
+    c_variadic = functions["c_variadic_func"]
+    assert c_variadic.is_c_linkage is True
+    assert c_variadic.is_variadic is True
+    assert c_variadic.mangled_name == "c_variadic_func"
+
+    assert functions["inner_func"].is_c_linkage is False
+
+
+def test_c_linkage_metadata_survives_pickle(decls):
+    functions = {
+        function.name: pickle.loads(pickle.dumps(function))
+        for function in decls.functions
+    }
+
+    assert functions["c_device_func"].is_c_linkage is True
+    assert functions["c_device_func"].is_variadic is False
+    assert functions["c_variadic_func"].is_c_linkage is True
+    assert functions["c_variadic_func"].is_variadic is True

--- a/ast_canopy/tests/test_mangled_name.py
+++ b/ast_canopy/tests/test_mangled_name.py
@@ -78,3 +78,13 @@ def test_c_linkage_metadata_survives_pickle(decls):
     assert functions["c_device_func"].is_variadic is False
     assert functions["c_variadic_func"].is_c_linkage is True
     assert functions["c_variadic_func"].is_variadic is True
+
+
+def test_variadic_member_function_metadata_survives_pickle(decls):
+    foo = next(struct for struct in decls.structs if struct.name == "Foo")
+    method = next(
+        method for method in foo.methods if method.name == "variadic_member"
+    )
+
+    assert method.is_variadic is True
+    assert pickle.loads(pickle.dumps(method)).is_variadic is True

--- a/numbast/src/numbast/deduction.py
+++ b/numbast/src/numbast/deduction.py
@@ -201,6 +201,8 @@ def _specialize_function(
             func.mangled_name,
             func.attributes,
             func.parse_entry_point,
+            is_variadic=func.is_variadic,
+            is_c_linkage=func.is_c_linkage,
         )
 
     return Function(
@@ -213,6 +215,8 @@ def _specialize_function(
         func.mangled_name,
         func.attributes,
         func.parse_entry_point,
+        is_c_linkage=func.is_c_linkage,
+        is_variadic=func.is_variadic,
     )
 
 

--- a/numbast/src/numbast/experimental/mlir/deduction.py
+++ b/numbast/src/numbast/experimental/mlir/deduction.py
@@ -201,6 +201,8 @@ def _specialize_function(
             func.mangled_name,
             func.attributes,
             func.parse_entry_point,
+            is_variadic=func.is_variadic,
+            is_c_linkage=func.is_c_linkage,
         )
 
     return Function(
@@ -213,6 +215,8 @@ def _specialize_function(
         func.mangled_name,
         func.attributes,
         func.parse_entry_point,
+        is_c_linkage=func.is_c_linkage,
+        is_variadic=func.is_variadic,
     )
 
 

--- a/numbast/src/numbast/experimental/mlir/tests/test_deduction.py
+++ b/numbast/src/numbast/experimental/mlir/tests/test_deduction.py
@@ -43,7 +43,7 @@ _CXX_SOURCE = textwrap.dedent(
 
     struct Box {
       template <typename T>
-      __device__ T mul(T a, T b) const { return a * b; }
+      __device__ T mul(T a, T b, ...) const { return a * b; }
 
       template <typename T>
       __device__ void write(T &out, T value) const { out = value; }
@@ -161,6 +161,8 @@ def test_non_templated_param_requires_match(deduction_decls):
         "float",
     ]
     assert func.return_type.unqualified_non_ref_type_name == "float"
+    assert func.is_variadic is True
+    assert func.is_c_linkage is False
 
     specialized, intent_errors = deduce_templated_overloads(
         qualname="add_int",

--- a/numbast/tests/test_deduction.py
+++ b/numbast/tests/test_deduction.py
@@ -43,7 +43,7 @@ _CXX_SOURCE = textwrap.dedent(
 
     struct Box {
       template <typename T>
-      __device__ T mul(T a, T b) const { return a * b; }
+      __device__ T mul(T a, T b, ...) const { return a * b; }
 
       template <typename T>
       __device__ void write(T &out, T value) const { out = value; }
@@ -161,6 +161,8 @@ def test_non_templated_param_requires_match(deduction_decls):
         "float",
     ]
     assert func.return_type.unqualified_non_ref_type_name == "float"
+    assert func.is_variadic is True
+    assert func.is_c_linkage is False
 
     specialized, intent_errors = deduce_templated_overloads(
         qualname="add_int",


### PR DESCRIPTION
## Summary

Expose two Clang FunctionDecl properties through AST Canopy's C++, pybind, and Python function models:

- is_c_linkage, sourced from FunctionDecl::isExternC()
- is_variadic, sourced from FunctionDecl::isVariadic()

C-linkage declarations now report their source spelling as mangled_name, matching the symbol exported by an object or LTOIR file. The pybind pickle format stores both fields while continuing to accept the previous five-element format.

## Motivation

A downstream binding generator needs an explicit ABI boundary:

- C linkage is the reliable condition for emitting a direct extern "C" declaration. Inferring it from whether a name happens to look mangled is heuristic.
- A parameter list does not encode the trailing ..., so variadic declarations otherwise look like fixed-arity functions and can be misgenerated.

This is parser metadata rather than CUDA-Oxide-specific behavior and is split out of #384 for independent review. No Rust binding-generation code is included here.

## Validation

- AST Canopy C++ library builds successfully
- AST Canopy Python wheel builds successfully
- pytest -q ast_canopy/tests/test_mangled_name.py: 3 passed
- all pre-commit hooks pass for the changed files

The broader local AST test suite remains affected by the existing CUDA 13.5/Clang 18 parse failure in crt/math_functions.hpp; the new test uses AST Canopy's header-isolated parsing mode and passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Function and member-function declarations now expose C-linkage and variadic status.
  * C-linkage functions retain their source names rather than using C++ name mangling.
  * Linkage and variadic metadata are preserved when declarations are serialized and restored, including older serialized data.
  * Specialized functions and methods retain these properties.

* **Tests**
  * Added coverage for linkage, variadic declarations, name handling, specialization, and serialization compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->